### PR TITLE
Feature/utc 917 item view styles

### DIFF
--- a/apps/drupal-default/particle_theme/templates/views/views-exposed-form--utc-library-item.html.twig
+++ b/apps/drupal-default/particle_theme/templates/views/views-exposed-form--utc-library-item.html.twig
@@ -1,0 +1,24 @@
+{#
+/**
+ * @file
+ * Theme override for a views exposed form.
+ *
+ * Available variables:
+ * - form: A render element representing the form.
+ *
+ * @see template_preprocess_views_exposed_form()
+ */
+#}
+{% if q is not empty %}
+  {#
+    This ensures that, if clean URLs are off, the 'q' is added first,
+    as a hidden form element, so that it shows up first in the POST URL.
+  #}
+{{ q }}
+{% endif %}
+  <div class="bg">
+<div class="form--inline clearfix">
+
+  {{ form }}
+  </div>
+</div>

--- a/apps/drupal-default/particle_theme/templates/views/views-exposed-form--utc-library-item.html.twig
+++ b/apps/drupal-default/particle_theme/templates/views/views-exposed-form--utc-library-item.html.twig
@@ -16,7 +16,7 @@
   #}
 {{ q }}
 {% endif %}
-  <div class="bg-white shadow-sm">
+  <div class="lib-item-form-container">
 <div class="form--inline clearfix lib-item-form">
   {{ form }}
   </div>

--- a/apps/drupal-default/particle_theme/templates/views/views-exposed-form--utc-library-item.html.twig
+++ b/apps/drupal-default/particle_theme/templates/views/views-exposed-form--utc-library-item.html.twig
@@ -16,9 +16,8 @@
   #}
 {{ q }}
 {% endif %}
-  <div class="bg">
-<div class="form--inline clearfix">
-
+  <div class="bg-white shadow-sm">
+<div class="form--inline clearfix lib-item-form">
   {{ form }}
   </div>
 </div>

--- a/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utclib_item_card.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utclib_item_card.css
@@ -1,10 +1,75 @@
-/*this is a hacky way to fix extra margin caused by themag theme at certain widths
-possibly look at padding and margin of layout blocks
-across site to determine whether all padding/margin should be dictated by block type vs.
-in the layout
+/* style view filters */
+.lib-item-form {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  padding: .625rem 2rem 1.625rem;
+}
+.lib-item-form .form-item {
+  margin-left: 0.5rem;
+}
 
-this class should be moved to a card grid scss file
-in particle */
+.lib-item-form .form-actions {
+  display: none;
+}
+.lib-item-form .form-item label,
+.lib-item-form legend {
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.5rem;
+  padding-top: 1rem;
+  @apply text-utc-new-blue-500;
+}
+
+/* style search */
+.lib-item-form .form-input {
+  height: 50px;
+  border: 1px solid;
+  border-radius: 0;
+  @apply bg-gray-200;
+  @apply border-gray-400;
+}
+
+.lib-item-form .js-form-item-search {
+  flex-grow: 10;
+}
+
+/* style select menus */
+.lib-item-form .form-select {
+  height: 50px;
+  width: 100%;
+  border: 1px solid;
+  border-radius: 0;
+  @apply bg-gray-200;
+  @apply border-gray-400;
+}
+
+.js-form-type-select {
+  flex-grow: 1;
+}
+
+/* style checkboxes */
+.lib-item-form .form-item label.option {
+  font-size: 1rem;
+}
+
+.lib-item-form .form-checkboxes {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+.lib-item-form .form-input.form-checkbox {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.lib-item-form .form-input.form-checkbox:checked {
+  @apply bg-utc-new-blue-500;
+}
+
+
+
 @media (min-width: 1024px) {
   .utc-item-two-col .utc-item-card__view-two-col {
     display: flex;

--- a/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utclib_item_card.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utclib_item_card.css
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  padding: .625rem 2rem 1.625rem;
+  padding: 1rem 0rem;
 }
 .lib-item-form .form-item {
   margin-left: 0.5rem;
@@ -21,31 +21,26 @@
   @apply text-utc-new-blue-500;
 }
 
-/* style search */
-.lib-item-form .form-input {
-  height: 50px;
-  border: 1px solid;
-  border-radius: 0;
-  @apply bg-gray-200;
-  @apply border-gray-400;
-}
+/* style search and select menus */
 
 .lib-item-form .js-form-item-search {
   flex-grow: 10;
 }
 
-/* style select menus */
-.lib-item-form .form-select {
-  height: 50px;
-  width: 100%;
-  border: 1px solid;
-  border-radius: 0;
-  @apply bg-gray-200;
-  @apply border-gray-400;
-}
-
 .js-form-type-select {
   flex-grow: 1;
+}
+
+.lib-item-form .form-input,
+.lib-item-form .form-select {
+  height: 55px;
+  width: 100%;
+  border: 2px solid;
+  border-radius: 0;
+  @apply bg-white;
+  @apply border-utc-new-blue-500;
+  @apply text-utc-new-blue-500;
+  font-size: 1.25rem;
 }
 
 /* style checkboxes */
@@ -68,7 +63,25 @@
   @apply bg-utc-new-blue-500;
 }
 
+/* if form is in full width container */
 
+.container-full .lib-item-form-container {
+  margin: 0rem -1rem;
+  @apply bg-gray-200;
+}
+
+.container-full .view-utc-library-item .view-content,
+.container-full .lib-item-form {
+  margin: 0rem 5rem 1rem;
+  padding: 1.5rem 0rem 3rem;
+}
+
+.container-full .lib-item-form .form-input,
+.container-full .lib-item-form .form-select {
+  border: 0;
+  border-radius: 0;
+  @apply border-gray-400;
+}
 
 @media (min-width: 1024px) {
   .utc-item-two-col .utc-item-card__view-two-col {


### PR DESCRIPTION
This updates the css for the library item view filters. When form styles/templates are addressed in particle these may need to be refactored. This approach uses mostly css for now.

**Standard View:**
<img width="1441" alt="Screen Shot 2020-09-28 at 3 36 41 PM" src="https://user-images.githubusercontent.com/50490141/94479280-928d5e00-01a2-11eb-863a-8bf07630d9fa.png">

**Full Container View:**
<img width="1441" alt="Screen Shot 2020-09-28 at 3 30 08 PM" src="https://user-images.githubusercontent.com/50490141/94479357-acc73c00-01a2-11eb-826e-65cc80182a94.png">



