### PR TITLE
Fix/utc 1068 webform style fixes

### DIFF
--- a/apps/drupal-default/particle_theme/templates/form/container.html.twig
+++ b/apps/drupal-default/particle_theme/templates/form/container.html.twig
@@ -20,7 +20,7 @@
  */
 #}
 {# Update the classes for grouped form items. This adds form-group to our button group for Search. #}
-{% set classes = ['form-group', 'mx-3'] %}
+{% set classes = ['form-group'] %}
 <div {{ attributes.addClass(classes) }}>
   {{ children }}
 </div>

--- a/source/default/_patterns/00-protons/index.js
+++ b/source/default/_patterns/00-protons/index.js
@@ -16,6 +16,7 @@ import './legacy/css/off-canvas.css';
 import './legacy/css/components/header/_utc_custom_header.css';
 import './legacy/css/components/header/_main-navigation.css';
 import './legacy/css/components/buttons/_buttons.css';
+import './legacy/css/components/forms/_forms.css';
 import './legacy/css/components/section/_section.css';
 import './legacy/css/components/UTC-custom-blocks/_utc_blockquotes.css';
 import './legacy/css/components/UTC-custom-blocks/_utc-button-group.css';

--- a/source/default/_patterns/00-protons/legacy/css/components/forms/_forms.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/forms/_forms.css
@@ -1,0 +1,183 @@
+.form-item,
+.form-actions {
+  margin-top: 0.375rem;
+  margin-bottom: 0.375rem;
+}
+
+table .form-item:last-child,
+table .form-actions:last-child {
+  margin-bottom: 0;
+}
+
+.form-item label:not(.option) {
+  margin-bottom: 0;
+  font-size: 0.778rem;
+  font-weight: bold;
+}
+
+.form-item input.error,
+.form-item textarea.error,
+.form-item select.error {
+  border: 1px solid red;
+}
+
+.form-actions .button {
+  margin-right: 0.278rem;
+}
+
+input[type='text'],
+input[type='time'],
+input[type='url'],
+input[type='password'],
+input[type='color'],
+input[type='week'],
+input[type='date'],
+input[type='tel'],
+input[type='email'],
+input[type='number'],
+input[type='datetime-local'],
+input[type='range'],
+input[type='month'],
+input[type='search'] {
+  background-color: #fff;
+  display: block;
+  width: 100%;
+  padding: 10px 1rem;
+  border: 1px solid;
+  border-color: #cfd8dc;
+  border-radius: .25rem;
+  box-shadow: inset 0 1px 1px rgba(38, 50, 56, 0.075);
+  color: #607d8b;
+  font-size: 0.85rem;
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color 0.15s;
+}
+
+@media (min-width: 768px) {
+  input[type='text'],
+  input[type='time'],
+  input[type='url'],
+  input[type='password'],
+  input[type='color'],
+  input[type='week'],
+  input[type='date'],
+  input[type='tel'],
+  input[type='email'],
+  input[type='number'],
+  input[type='datetime-local'],
+  input[type='range'],
+  input[type='month'],
+  input[type='search'] {
+    font-size: 0.85rem;
+  }
+}
+
+select {
+  background-color: #fff;
+  display: block;
+  padding: 10px 1rem;
+  border: 1px solid;
+  border-color: #cfd8dc;
+  border-radius: 0;
+  box-shadow: inset 0 1px 1px rgba(38, 50, 56, 0.075);
+  color: #607d8b;
+  font-size: 0.85rem;
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color 0.15s;
+  width: auto;
+  height: 40px;
+}
+
+textarea {
+  background-color: #fff;
+  display: block;
+  width: 100%;
+  padding: 10px 1rem;
+  border: 1px solid;
+  border-color: #cfd8dc;
+  border-radius: 0;
+  box-shadow: inset 0 1px 1px rgba(38, 50, 56, 0.075);
+  color: #607d8b;
+  font-size: 0.85rem;
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color 0.15s;
+}
+
+input[type='radio'] {
+  margin-left: 3px;
+}
+
+.form-checkboxes .form-item,
+.form-radios .form-item {
+  margin-top: 0.1em;
+  margin-bottom: 0.1em;
+}
+
+.form-checkboxes .form-item label.option,
+.form-radios .form-item label.option {
+  font-size: 0.9rem;
+}
+
+.form-type-radio .description,
+.form-type-checkbox .description {
+  margin-left: 0;
+}
+
+.description {
+  margin: 10px 0 0;
+  font-size: 0.778rem;
+  color: #90a4ae;
+}
+
+.description a {
+  text-decoration: underline;
+}
+
+details summary {
+  display: block;
+  background-color: #eceff1;
+  padding: 1rem;
+  font-size: 0.9rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  transition: all 0.2s ease-in-out;
+}
+
+details summary:before {
+  font-family: 'Font Awesome 5 Free';
+  content: '\f107';
+  margin-right: 10px;
+}
+
+details summary:hover {
+  background-color: #cfd8dc;
+}
+
+details summary[aria-expanded='true']:before {
+  content: '\f106';
+}
+
+details summary::-webkit-details-marker {
+  display: none;
+}
+
+details .details-wrapper {
+  background-color: #fff;
+  padding: 1.5rem;
+  border: 1px solid #cfd8dc;
+  border-top: none;
+}
+
+details a.details-title {
+  color: #000;
+  text-decoration: none;
+}
+
+details .action {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #cfd8dc;
+}


### PR DESCRIPTION
This relates to issue 1068 related to webform styling. This pull:

1. Creates a new _forms.css file.
2. Copies themag styles over to this file and converts them from sass to css.

Essentially, all visuals for forms should still be the same (and are the same when I compare w/ production). I figured it made sense to do this basic setup step, do a pull in utccloud that deletes the _forms.scss file from themag, and then move on from there with making some small changes to the form visuals.