### PR TITLE
Fix/utc 1139 item card view edits

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--block--utc-library-item.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--block--utc-library-item.html.twig
@@ -35,7 +35,8 @@
 ] | sort | join(' ') | trim %}
 
 	{% set content = {
-	card_link: content.field_utclib_item_link.0['#url'],
+    card_mobile_stack: content.field_utclib_mobile_stack[0]|render == 'On',
+	  card_link: content.field_utclib_item_link.0['#url'],
     card_image: content.field_utclib_item_image|field_value,
     card_title: content.field_utclib_item_title|field_value,
     card_text: content.field_utclib_item_body|field_value,  

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-library-item-base.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-library-item-base.html.twig
@@ -32,6 +32,7 @@
   'utc-item-card',
   'h-100',
   card_link ? 'utc-item-card--card-link',
+  card_mobile_stack ? 'utc-item-card--mobile-stack',
 ] | sort | join(' ') | trim %}
 
 

--- a/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utclib_item_card.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utclib_item_card.css
@@ -112,6 +112,10 @@
     0 4px 6px -2px rgba(0, 0, 0, 0.05);
 }
 
+.utc-item-card--mobile-stack {
+  flex-direction: column;
+}
+
 a .utc-item-card:hover {
   @apply bg-gray-200;
   box-shadow: 0 10px 15px -3px rgba(#000, 0.2), 0 4px 6px -2px rgba(#000, 0.05);
@@ -193,7 +197,7 @@ h2:first-child {
   display: inline-block;
   padding: 0;
   margin-bottom: 0;
-}
+} 
 
 .utc-item-card__badges ul li {
   @apply bg-gray-300;

--- a/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utclib_item_card.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utclib_item_card.css
@@ -14,7 +14,7 @@
 }
 .lib-item-form .form-item label,
 .lib-item-form legend {
-  font-size: 1.2rem;
+  font-size: 1rem;
   line-height: 1.5rem;
   margin-bottom: 0.5rem;
   padding-top: 1rem;
@@ -33,14 +33,14 @@
 
 .lib-item-form .form-input,
 .lib-item-form .form-select {
-  height: 55px;
+  height: 50px;
   width: 100%;
   border: 2px solid;
   border-radius: 0;
   @apply bg-white;
   @apply border-utc-new-blue-500;
   @apply text-utc-new-blue-500;
-  font-size: 1.25rem;
+  font-size: 1rem;
 }
 
 /* style checkboxes */


### PR DESCRIPTION
This pull updates a few things relate to the utclib item cards:

- [x]  modifies the filter font sizes for library item card views

- [x] sets up styles and twig for the option to stack card image and content on mobile or keep landscape (will add configuration on a pull in utccloud)

![Uploading Screen Shot 2020-10-14 at 4.13.31 PM.png…]()
