### PR TITLE
UTC-338 accordion style updates

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/ckeditor/accordion.css
+++ b/source/default/_patterns/00-protons/legacy/css/ckeditor/accordion.css
@@ -1,52 +1,73 @@
 .ckeditor-accordion-container > dl dt > a {
-	display: block;
-	font-size: 500;
-	/* background-color: white; */
-	@apply bg-gray-100;
-	/* color: gray; */
-	@apply text-gray-700;
-	cursor: pointer;
-	-webkit-transition: background-color 300ms;
-	transition: background-color 300ms;
-	border-bottom: 1px solid gray;
-	/* @apply border-bottom-gray-400; */
+  display: block;
+  font-size: 500;
+  @apply bg-white;
+  @apply text-utc-new-blue-500;
+  cursor: pointer;
+  -webkit-transition: background-color 300ms;
+  transition: background-color 300ms;
+  border: 3px solid;
+  @apply border-gray-400;
+  margin: -3px 0px;
 }
 
 .ckeditor-accordion-container > dl dt > a:hover {
-	/* background-color: gray; */
-	@apply bg-gray-400;
-	border-bottom: 0;
-	text-decoration: none;
+  @apply bg-gray-400;
+  text-decoration: none;
 }
 
 .ckeditor-accordion-container > dl dt.active > a {
-	/* background-color: gray; */
-	@apply bg-gray-400;
+  @apply bg-gray-400;
+  @apply border-utc-new-blue-500;
+  border: 3px solid;
+  @apply border-gray-400;
+  border-bottom: 3px solid;
+  margin-top: 3px;
+  transition: border-color 1s ease-out;
 }
 
 .ckeditor-accordion-container > dl dt.active > a:hover {
-	/* color: gray; */
-	@apply text-gray-400;
-	/* background-color: gray; */
-	@apply bg-gray-800;
+  @apply bg-gray-400;
+  @apply border-gray-400;
+  border-bottom: 3px solid;
 }
 
 /* contents */
 .ckeditor-accordion-container > dl dd {
-	display: none;
-	padding: 0 15px;
-	margin: 0;
-	will-change: height;
+  display: none;
+  padding: 0.75rem 1.25rem;
+  margin: 0;
+  will-change: height;
+}
+
+.ckeditor-accordion-container > dl dd.active {
+  @apply bg-white;
+  border: 3px solid;
+  @apply border-utc-new-blue-500;
+  border-top: 0;
+  margin-bottom: 3px;
+  transition: border-color 1s ease-out;
 }
 
 .ckeditor-accordion-container > dl {
-	position: relative;
-	border: 0;
+  position: relative;
+  border: 0;
+  padding-left: 0;
 }
 
 .ckeditor-accordion-container > dl dt > a > .ckeditor-accordion-toggle::before,
 .ckeditor-accordion-container > dl dt > a > .ckeditor-accordion-toggle::after {
-	/* background: gray; */
-	@apply bg-gray-700;
+  @apply bg-gray-700;
+}
 
+.ckeditor-accordion-container > dl dt:last-of-type > a  {
+  border-bottom: 3px solid;
+  @apply border-gray-400;
+}
+.ckeditor-accordion-container > dl dt.active:last-of-type {
+@apply bg-gray-400;
+border: 3px solid;
+@apply border-utc-new-blue-500;
+border-bottom: 0;
+transition: border-color 1s ease-out;
 }

--- a/source/default/_patterns/00-protons/legacy/css/ckeditor/accordion.css
+++ b/source/default/_patterns/00-protons/legacy/css/ckeditor/accordion.css
@@ -8,25 +8,25 @@
   -webkit-transition: 300ms;
   transition: 300ms;
   border: 2px solid;
-  @apply border-gray-400;
+  @apply border-gray-300;
   margin: 5px 0px 0px;
 }
 
 .ckeditor-accordion-container > dl dt > a:hover {
-  @apply bg-gray-400;
+  @apply bg-gray-300;
   @apply border-utc-new-blue-500;
   text-decoration: none;
 }
 
 .ckeditor-accordion-container > dl dt.active > a {
-  @apply bg-gray-400;
+  @apply bg-gray-300;
   @apply border-utc-new-blue-500;
   border: 2px solid;
   border-bottom: none;
 }
 
 .ckeditor-accordion-container > dl dt.active > a:hover {
-  @apply bg-gray-400;
+  @apply bg-gray-300;
   @apply border-utc-new-blue-500;
   border-bottom: none;
 }

--- a/source/default/_patterns/00-protons/legacy/css/ckeditor/accordion.css
+++ b/source/default/_patterns/00-protons/legacy/css/ckeditor/accordion.css
@@ -1,35 +1,34 @@
-.ckeditor-accordion-container > dl dt > a {
+.ckeditor-accordion-container > dl dt > a,
+.ckeditor-accordion-container > dl dt:last-of-type > a {
   display: block;
   font-size: 500;
   @apply bg-white;
   @apply text-utc-new-blue-500;
   cursor: pointer;
-  -webkit-transition: background-color 300ms;
-  transition: background-color 300ms;
-  border: 3px solid;
+  -webkit-transition: 300ms;
+  transition: 300ms;
+  border: 2px solid;
   @apply border-gray-400;
-  margin: -3px 0px;
+  margin: 5px 0px 0px;
 }
 
 .ckeditor-accordion-container > dl dt > a:hover {
   @apply bg-gray-400;
+  @apply border-utc-new-blue-500;
   text-decoration: none;
 }
 
 .ckeditor-accordion-container > dl dt.active > a {
   @apply bg-gray-400;
   @apply border-utc-new-blue-500;
-  border: 3px solid;
-  @apply border-gray-400;
-  border-bottom: 3px solid;
-  margin-top: 3px;
-  transition: border-color 1s ease-out;
+  border: 2px solid;
+  border-bottom: none;
 }
 
 .ckeditor-accordion-container > dl dt.active > a:hover {
   @apply bg-gray-400;
-  @apply border-gray-400;
-  border-bottom: 3px solid;
+  @apply border-utc-new-blue-500;
+  border-bottom: none;
 }
 
 /* contents */
@@ -42,11 +41,10 @@
 
 .ckeditor-accordion-container > dl dd.active {
   @apply bg-white;
-  border: 3px solid;
+  border: 2px solid;
   @apply border-utc-new-blue-500;
   border-top: 0;
-  margin-bottom: 3px;
-  transition: border-color 1s ease-out;
+  
 }
 
 .ckeditor-accordion-container > dl {
@@ -58,16 +56,4 @@
 .ckeditor-accordion-container > dl dt > a > .ckeditor-accordion-toggle::before,
 .ckeditor-accordion-container > dl dt > a > .ckeditor-accordion-toggle::after {
   @apply bg-gray-700;
-}
-
-.ckeditor-accordion-container > dl dt:last-of-type > a  {
-  border-bottom: 3px solid;
-  @apply border-gray-400;
-}
-.ckeditor-accordion-container > dl dt.active:last-of-type {
-@apply bg-gray-400;
-border: 3px solid;
-@apply border-utc-new-blue-500;
-border-bottom: 0;
-transition: border-color 1s ease-out;
 }

--- a/source/default/_patterns/00-protons/legacy/css/global.css
+++ b/source/default/_patterns/00-protons/legacy/css/global.css
@@ -76,19 +76,19 @@
   font-weight: normal;
 }
 
-.UTCtextblock__links a:not(.btn):not(.dm-profile-tabs__link) {
+.UTCtextblock__links a:not(.btn):not(.dm-profile-tabs__link):not(.ckeditor-accordion-toggler) {
   @apply text-blue-500;
   border-bottom: 1.5px solid #4299e1;
   text-decoration: none;
 }
 
-.UTCtextblock__links a:not(.btn):not(.dm-profile-tabs__link):hover {
+.UTCtextblock__links a:not(.btn):not(.dm-profile-tabs__link):hover:not(.ckeditor-accordion-toggler):hover {
   @apply text-utc-new-blue-500;
   border-bottom: 1.5px solid #112e51;
   text-decoration: none;
 }
 
-.UTCtextblock__links a:not(.btn):not(.dm-profile-tabs__link):active {
+.UTCtextblock__links a:not(.btn):not(.dm-profile-tabs__link):active:not(.ckeditor-accordion-toggler):active {
   color: #fdb736;
   border-bottom: 1.5px solid #fdb736;
   text-decoration: none;

--- a/source/default/_patterns/00-protons/legacy/css/global.css
+++ b/source/default/_patterns/00-protons/legacy/css/global.css
@@ -50,24 +50,26 @@
   @apply text-black;
   color: black;
 }
-.utc-card-2__text a:not(.btn),
-.utc-sidebar-card a:not(.btn),
-.utc-item-card a:not(.btn)
+.utc-card-2__text a:not(.btn):not(.ckeditor-accordion-toggler),
+.utc-sidebar-card a:not(.btn):not(.ckeditor-accordion-toggler),
+.utc-item-card a:not(.btn):not(.ckeditor-accordion-toggler)
  {
   @apply text-blue-500;
   border-bottom: 1.5px solid #4299e1;
   text-decoration: none;
 }
 
-.utc-card-2__text a:not(.btn):hover,
-.utc-sidebar-card a:not(.btn):hover,
-.utc-item-card a:not(.btn):hover {
+.utc-card-2__text a:not(.btn):not(.ckeditor-accordion-toggler):hover,
+.utc-sidebar-card a:not(.btn):not(.ckeditor-accordion-toggler):hover,
+.utc-item-card a:not(.btn):not(.ckeditor-accordion-toggler):hover {
   @apply text-utc-new-blue-500;
   border-bottom: 1.5px solid #112e51;
   text-decoration: none;
 }
 
-.utc-card-2__text a:not(.btn):active {
+.utc-card-2__text a:not(.btn):not(.ckeditor-accordion-toggler):active,
+.utc-sidebar-card a:not(.btn):not(.ckeditor-accordion-toggler):active,
+.utc-item-card a:not(.btn):not(.ckeditor-accordion-toggler):active {
   color: #fdb736;
   border-bottom: 1.5px solid #fdb736;
   text-decoration: none;


### PR DESCRIPTION
Relates to issue: https://github.com/UTCWeb/utccloud/issues/338

This updates the visuals for the accordion styles. One repercussion of this update is that athere will be too much top spacing for accordions already in use where users have manually added additional top spacing to the content (e.g. outdoor spaces accordions). 

![accordions-2](https://user-images.githubusercontent.com/50490141/97203139-d1570980-178a-11eb-88b1-a012443ab8c6.gif)


![accordions-1](https://user-images.githubusercontent.com/50490141/97203140-d1efa000-178a-11eb-9caf-26c893271535.gif)
