### PR TITLE
Fix/lib-item-card-view

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--block--utc-library-item.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--block--utc-library-item.html.twig
@@ -35,7 +35,7 @@
 ] | sort | join(' ') | trim %}
 
 	{% set content = {
-    card_mobile_stack: content.field_utclib_mobile_stack[0]|render == 'On',
+    card_mobile_stack: content.field_utclib_mobile_stack[0]|render == 'On' ? 'utc-item-card--mobile-stack' ,
 	  card_link: content.field_utclib_item_link.0['#url'],
     card_image: content.field_utclib_item_image|field_value,
     card_title: content.field_utclib_item_title|field_value,

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-library-item-base.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-library-item-base.html.twig
@@ -32,7 +32,7 @@
   'utc-item-card',
   'h-100',
   card_link ? 'utc-item-card--card-link',
-  card_mobile_stack ? 'utc-item-card--mobile-stack',
+  content.card_mobile_stack,
 ] | sort | join(' ') | trim %}
 
 
@@ -51,7 +51,7 @@
 				<div class="utc-item-card__content">
 
 					{% if content.card_title %}
-						<h3 class="utc-item-card__title">{{ content.card_title }}
+						<h3 class="utc-item-card__title">{{ content.card_title }} 
 						</h3>
 					{% endif %}
 

--- a/apps/drupal-default/particle_theme/templates/views/views-view-unformatted--utc-library-item.html.twig
+++ b/apps/drupal-default/particle_theme/templates/views/views-view-unformatted--utc-library-item.html.twig
@@ -28,7 +28,8 @@
 <div class="utc-item-card__view-two-col">
 {% for key,row in rows %}
 	{% set content = {
-	card_link: view.style_plugin.getField(key, 'field_utclib_item_link'),
+    card_mobile_stack: view.style_plugin.getField(key, 'field_utclib_mobile_stack'),
+	  card_link: view.style_plugin.getField(key, 'field_utclib_item_link'),
     card_image: view.style_plugin.getField(key, 'field_utclib_item_image'),
     card_title: view.style_plugin.getField(key, 'field_utclib_item_title'),
     card_text: view.style_plugin.getField(key, 'field_utclib_item_body')|raw,  
@@ -37,7 +38,8 @@
     card_divider: view.style_plugin.getField(key, 'field_utclib_item_divider')|render|striptags|clean_class,
  } %}
 
-	{% embed 'block--utc-library-item-base.html.twig' with content %}
+
+{% embed 'block--utc-library-item-base.html.twig' with content %}
 {% block badges %}
 	{% if content.card_badges %}
 		<div class="utc-item-card__badges">


### PR DESCRIPTION
This fixes the mobile stack card option for cards add through the library item view. Basically, adds this variable to the twig template for the view. Will add the required config update on utccloud after this goes in.