### PR TITLE
UTC-116: Employee blocks without preprocessing

### DIFF
--- a/apps/drupal-default/particle_theme/includes/block.theme.inc
+++ b/apps/drupal-default/particle_theme/includes/block.theme.inc
@@ -51,27 +51,6 @@ function particle_theme_suggestions_block_alter(&$suggestions, $variables)
 
 function particle_preprocess_block(&$variables)
 {
-    if ($variables['plugin_id'] == 'entity_browser_block:employee_blocks') {
-        $content = $variables['elements']['content'];
-
-        $mediaId=$content[0]['#block_content']->get('field_employee_picture')->target_id;
-        for ($index = 0; $index <= sizeof($content)-1; $index++) {
-            $employee_picture_id=$content[$index]['#block_content']->get('field_employee_picture')->target_id;
-            $load_media_entity = Media::load($employee_picture_id);
-            $employee_picture_uri = $load_media_entity->field_image->entity->getFileUri();
-            $variables['employeeimages'][$index] = $employee_picture_uri;
-            $variables['field_view_mode'][$index] = $content[$index]['#view_mode'];
-            $variables['field_employee_department'][$index] = $content[$index]['#block_content']->get('field_employee_department')->value;
-            $variables['field_employee_email'][$index] = $content[$index]['#block_content']->get('field_employee_email')->value;
-            $variables['field_employee_title'][$index] = $content[$index]['#block_content']->get('field_employee_title')->value;
-            $variables['field_employee_first_name'][$index] = $content[$index]['#block_content']->get('field_employee_first_name')->value;
-            $variables['field_employee_last_name'][$index] = $content[$index]['#block_content']->get('field_employee_last_name')->value;
-            $variables['field_employee_office_location'][$index] = $content[$index]['#block_content']->get('field_employee_office_location')->value;
-            $variables['field_employee_telephone'][$index] = $content[$index]['#block_content']->get('field_employee_telephone')->value;
-            $variables['field_employee_website'][$index] = $content[$index]['#block_content']->get('field_employee_website')->view('url');
-        }
-    }
-
     if ($variables['plugin_id'] == 'entity_browser_block:department_info') {
         $content = $variables['elements']['content'];
         for ($index = 0; $index <= sizeof($content)-1; $index++) {

--- a/apps/drupal-default/particle_theme/templates/block/block--entity-browser-block--employee-blocks.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--entity-browser-block--employee-blocks.html.twig
@@ -33,7 +33,6 @@
 {# {{attribute(content, 3).field_employee_picture}} #}
 {# {{content|length}} #}
 	<div class="row">
-
 		{# {{content.0.field_employee_picture}} #}
 		{% for i in 0..content|length %}
 
@@ -47,14 +46,6 @@
 				employee_email: attribute(content, i).field_employee_email,
 				view_field: content.0["#view_mode"],
 			} %}
-
-			{# <h2>{{content.0["#view_mode"]}}</h2> #}
-			{# <h2>{{dump(view_field)}}</h2> #}
-           {# $content[$index]['#view_mode'] #}
-			{# {{variables.employee_image}} #}
-			{# {{ dump(loop.index0)}} #}
-  				{# {{ content.i.field_employee_picture }} #}
-				  {# {{attribute(content, i).field_employee_picture}} #}
 
 			{% if variables.view_field != "default" and variables.view_field != "full" and variables.view_field != "utc_small_teaser_card" 
 			and variables.view_field != "utc_original_size"%}
@@ -92,9 +83,7 @@
 								<hr/>
 								{% if variables.employee_email %}
 									<p>
-										<i class="fas fa-envelope fa-fw"></i>&nbsp;<a href="mailto:{{ variables.employee_email }}">
-											{{ variables.employee_email }}
-										</a>
+										<i class="fas fa-envelope fa-fw"></i>{{ variables.employee_email }}
 									</p>
 								{% endif %}
 								{% if variables.employee_office %}
@@ -104,10 +93,8 @@
 								{% endif %}
 								{% if variables.employee_telephone %}
 									<p>
-										<i class="fas fa-phone-alt fa-fw"></i>
-										<a href={{ "tel:" ~ field_employee_telephone[key]}}>
-											{{ variables.employee_telephone }}
-										</a>
+										<i class="fas fa-phone-alt fa-fw"></i>{{ variables.employee_telephone }}
+										
 									</p>
 								{% endif %}
 							</div>
@@ -176,7 +163,7 @@
 					</div>
 				</div>
 			{% endif %}
-			{{devel_breakpoint()}}
+			{# {{devel_breakpoint()}} #}
 		{% endfor %}
 	</div>
 	{# {% endif %} #}

--- a/apps/drupal-default/particle_theme/templates/block/block--entity-browser-block--employee-blocks.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--entity-browser-block--employee-blocks.html.twig
@@ -28,12 +28,26 @@
 #}
 
 {% block content %}
+{{content.0.field_employee_picture}}
+{{content.field_employee_picture}}
+{{attribute(content, 3).field_employee_picture}}
+{{content|length}}
 	<div class="row">
-		{% for key,element in employeeimages %}
+
+		{# {{content.0.field_employee_picture}} #}
+		{% for i in 0..content|length %}
+  				{# {{ content.i.field_employee_picture }} #}
+				  {{attribute(content, i).field_employee_picture}}
+				  inside the loop
+		{% endfor %}
+
+		{% for key,element in content %}
+		{{ dump(loop.index0)}}
+		{% set demo =0 %}
 			{% set variables = {
-    			employee_first: field_employee_first_name[key],
+    			employee_first: content.0.field_employee_first_name,
 				employee_last: field_employee_last_name[key],
-				employee_image: element|image_style('utc_employee_small_310x450_'),
+				employee_image: content.field_employee_picture[key],
 				employee_website: field_employee_website[key]|field_value,
 				employee_title: field_employee_title[key],
 				employee_email: field_employee_email[key],
@@ -59,7 +73,8 @@
 						{% if variables.employee_website is not empty %}
 							<a href={{ variables.employee_website }}>
 							{% endif %}
-							<img class="h-auto" src="{{ variables.employee_image }}"/>
+							{{variables.employee_image}}
+							{# <img class="h-auto" src="{{ variables.employee_image }}"/> #}
 							{% if variables.employee_website is not empty %}
 							</a>
 						{% endif %}
@@ -161,7 +176,7 @@
 					</div>
 				</div>
 			{% endif %}
-
+			{{devel_breakpoint()}}
 		{% endfor %}
 	</div>
 	{# {% endif %} #}

--- a/apps/drupal-default/particle_theme/templates/block/block--entity-browser-block--employee-blocks.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--entity-browser-block--employee-blocks.html.twig
@@ -30,8 +30,8 @@
 {% block content %}
 {# {{content.0.field_employee_picture}}
 {{content.field_employee_picture}} #}
-{{attribute(content, 3).field_employee_picture}}
-{{content|length}}
+{# {{attribute(content, 3).field_employee_picture}} #}
+{# {{content|length}} #}
 	<div class="row">
 
 		{# {{content.0.field_employee_picture}} #}
@@ -41,6 +41,7 @@
 				employee_image: attribute(content, i).field_employee_picture,
 				employee_first: attribute(content, i).field_employee_first_name,
 				employee_last: attribute(content, i).field_employee_last_name,
+				employee_telephone: attribute(content, i).field_employee_telephone,
 				employee_website: attribute(content, i).field_employee_website|field_value,
 				employee_title: attribute(content, i).field_employee_title,
 				employee_email: attribute(content, i).field_employee_email,
@@ -48,13 +49,12 @@
 			} %}
 
 			{# <h2>{{content.0["#view_mode"]}}</h2> #}
-			<h2>{{dump(view_field)}}</h2>
+			{# <h2>{{dump(view_field)}}</h2> #}
            {# $content[$index]['#view_mode'] #}
 			{# {{variables.employee_image}} #}
 			{# {{ dump(loop.index0)}} #}
   				{# {{ content.i.field_employee_picture }} #}
 				  {# {{attribute(content, i).field_employee_picture}} #}
-				  inside the loop
 
 			{% if variables.view_field != "default" and variables.view_field != "full" and variables.view_field != "utc_small_teaser_card" 
 			and variables.view_field != "utc_original_size"%}

--- a/apps/drupal-default/particle_theme/templates/block/block--entity-browser-block--employee-blocks.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--entity-browser-block--employee-blocks.html.twig
@@ -43,6 +43,7 @@
 				employee_telephone: attribute(content, i).field_employee_telephone,
 				employee_website: attribute(content, i).field_employee_website|field_value,
 				employee_title: attribute(content, i).field_employee_title,
+				employee_office: attribute(content, i).field_employee_office_location,
 				employee_email: attribute(content, i).field_employee_email,
 				view_field: content.0["#view_mode"],
 			} %}
@@ -50,7 +51,7 @@
 			{% if variables.view_field != "default" and variables.view_field != "full" and variables.view_field != "utc_small_teaser_card" 
 			and variables.view_field != "utc_original_size"%}
 				<h3>
-					Only default, full and original views mode are supported
+					Only default, full and utc_small_teaser_card, and wide card are supported
 				</h3>
 				<h3>
 					The employee block for
@@ -59,6 +60,56 @@
 					needs to be updated</h3>
 			{% endif %}
 			{% if variables.view_field == "default" or variables.view_field == "full" or variables.view_field == "utc_small_teaser_card" %}
+				<div class="col-lg-4 col-md-6 employee-card__container">
+					<div class="employee-card h-100">
+						{% if variables.employee_website is not empty %}
+							<a href={{ variables.employee_website }}>
+							{% endif %}
+							{{variables.employee_image}}
+							{# <img class="h-auto" src="{{ variables.employee_image }}"/> #}
+							{% if variables.employee_website is not empty %}
+							</a>
+						{% endif %}
+						{# TODO card-body needs to be refactored as is used in the aggregator block #}
+						<div class="employee-card__body">
+							<div class="employee-card__info">
+								<h3 class="employee-card__name">
+									{{ variables.employee_first}}
+									{{ variables.employee_last}}
+								</h3>
+								<p class="employee-card__title">
+									{{ variables.employee_title }}
+								</p>
+								{% if variables.employee_email %}
+									<p>
+										<i class="fas fa-envelope fa-fw"></i>{{ variables.employee_email }}
+									</p>
+								{% endif %}
+								{% if variables.employee_office %}
+									<p>
+										<i class="fas fa-map-marker fa-fw"></i>&nbsp;{{ variables.employee_office|raw }}
+									</p>
+								{% endif %}
+								{% if variables.employee_telephone %}
+									<p>
+										<i class="fas fa-phone-alt fa-fw"></i> {{ variables.employee_telephone }}
+										
+									</p>
+								{% endif %}
+							</div>
+							{% if variables.employee_website  is not empty %}
+								<div class="employee-card__button">
+									<a class="btn btn-light" href={{ variables.employee_website }}>More info</a>
+								</div>
+							{% endif %}
+
+						</div>
+					</div>
+				</div>
+			{% endif %}
+
+			{# TODO Adjust the folling to add Wide version #}
+			{% if variables.view_field == "utc_original_size" %}
 				<div class="col-lg-4 col-md-6 employee-card__container">
 					<div class="employee-card h-100">
 						{% if variables.employee_website is not empty %}
@@ -93,63 +144,8 @@
 								{% endif %}
 								{% if variables.employee_telephone %}
 									<p>
-										<i class="fas fa-phone-alt fa-fw"></i>{{ variables.employee_telephone }}
+										<i class="fas fa-phone-alt fa-fw"></i> {{ variables.employee_telephone }}
 										
-									</p>
-								{% endif %}
-							</div>
-							{% if variables.employee_website  is not empty %}
-								<div class="employee-card__button">
-									<a class="btn btn-light" href={{ variables.employee_website }}>More info</a>
-								</div>
-							{% endif %}
-
-						</div>
-					</div>
-				</div>
-			{% endif %}
-
-
-			{% if variables.view_field == "utc_original_size" %}
-				<div class="col-lg-4 col-md-6 employee-card__container">
-					<div class="employee-card h-100">
-						{% if variables.employee_website is not empty %}
-							<a href={{ variables.employee_website }}>
-							{% endif %}
-							{# <img class="h-auto" src="{{ variables.employee_image }}"/> #}
-							{% if variables.employee_website is not empty %}
-							</a>
-						{% endif %}
-						{# TODO card-body needs to be refactored as is used in the aggregator block #}
-						<div class="employee-card__body">
-							<div class="employee-card__info">
-								<h3 class="employee-card__name">
-									{{ variables.employee_first }}
-									{{ variables.employee_last }}
-								</h3>
-								<p class="employee-card__title">
-									{{ variables.employee_title }}
-								</p>
-
-								<hr/>
-								{% if variables.employee_email %}
-									<p>
-										<i class="fas fa-envelope fa-fw"></i>&nbsp;<a href="mailto:{{ variables.employee_email }}">
-											{{ variables.employee_email }}
-										</a>
-									</p>
-								{% endif %}
-								{% if variables.employee_office %}
-									<p>
-										<i class="fas fa-map-marker fa-fw"></i>&nbsp;{{ variables.employee_office }}
-									</p>
-								{% endif %}
-								{% if variables.employee_telephone %}
-									<p>
-										<i class="fas fa-phone-alt fa-fw"></i>
-										<a href={{ "tel:" ~ field_employee_telephone[key]}}>
-											{{ variables.employee_telephone }}
-										</a>
 									</p>
 								{% endif %}
 							</div>

--- a/apps/drupal-default/particle_theme/templates/block/block--entity-browser-block--employee-blocks.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--entity-browser-block--employee-blocks.html.twig
@@ -34,7 +34,7 @@
 {# {{content|length}} #}
 	<div class="row">
 		{# {{content.0.field_employee_picture}} #}
-		{% for i in 0..content|length %}
+		{% for i in 0..(content|length) - 1 %}
 
 			{% set variables = {
 				employee_image: attribute(content, i).field_employee_picture,

--- a/apps/drupal-default/particle_theme/templates/block/block--entity-browser-block--employee-blocks.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--entity-browser-block--employee-blocks.html.twig
@@ -28,33 +28,33 @@
 #}
 
 {% block content %}
-{{content.0.field_employee_picture}}
-{{content.field_employee_picture}}
+{# {{content.0.field_employee_picture}}
+{{content.field_employee_picture}} #}
 {{attribute(content, 3).field_employee_picture}}
 {{content|length}}
 	<div class="row">
 
 		{# {{content.0.field_employee_picture}} #}
 		{% for i in 0..content|length %}
-  				{# {{ content.i.field_employee_picture }} #}
-				  {{attribute(content, i).field_employee_picture}}
-				  inside the loop
-		{% endfor %}
 
-		{% for key,element in content %}
-		{{ dump(loop.index0)}}
-		{% set demo =0 %}
 			{% set variables = {
-    			employee_first: content.0.field_employee_first_name,
-				employee_last: field_employee_last_name[key],
-				employee_image: content.field_employee_picture[key],
-				employee_website: field_employee_website[key]|field_value,
-				employee_title: field_employee_title[key],
-				employee_email: field_employee_email[key],
-				employee_telephone: field_employee_telephone[key],
-				employee_office: field_employee_office_location[key],	
-				view_field: field_view_mode[key],
- 		   } %}
+				employee_image: attribute(content, i).field_employee_picture,
+				employee_first: attribute(content, i).field_employee_first_name,
+				employee_last: attribute(content, i).field_employee_last_name,
+				employee_website: attribute(content, i).field_employee_website|field_value,
+				employee_title: attribute(content, i).field_employee_title,
+				employee_email: attribute(content, i).field_employee_email,
+				view_field: content.0["#view_mode"],
+			} %}
+
+			{# <h2>{{content.0["#view_mode"]}}</h2> #}
+			<h2>{{dump(view_field)}}</h2>
+           {# $content[$index]['#view_mode'] #}
+			{# {{variables.employee_image}} #}
+			{# {{ dump(loop.index0)}} #}
+  				{# {{ content.i.field_employee_picture }} #}
+				  {# {{attribute(content, i).field_employee_picture}} #}
+				  inside the loop
 
 			{% if variables.view_field != "default" and variables.view_field != "full" and variables.view_field != "utc_small_teaser_card" 
 			and variables.view_field != "utc_original_size"%}


### PR DESCRIPTION
Check it out.
The view mode for the group is defined by the first element on the employee block group. This should allow us to avoid two issues.
1) People choosing a wide array of options on one block.
2) Buy time while we figure how to add that 0 dynamically `content.0["#view_mode"]`

This PR requires a few configuration changes to the employee picture field on the UTC employee block. I will include that on the PR going into UTCCloud.

![Screen Shot 2020-10-29 at 1 16 45 PM](https://user-images.githubusercontent.com/39039024/97608699-0e203c00-19e9-11eb-9765-f780223cba27.png)

Warning: Some styles need minor updates due to the drupal render array including field information.
