### PR TITLE
UTC-1174: Makes tailwind purge aware of Drupal templates

### DIFF
--- a/source/default/tailwind.config.js
+++ b/source/default/tailwind.config.js
@@ -16,7 +16,7 @@ const fontFamily = require('./tokens/font-family.tailwind');
 module.exports = {
   // Purge CSS from Tailwind Only.
   purge: {
-    content: [path.resolve(__dirname, '_patterns/**/*.*')],
+    content: [path.resolve(__dirname, '_patterns/**/*.*'), path.resolve(__dirname, '../../apps/drupal-default/particle_theme/templates/**/*.*')],
     options: {
       // Whitelist Non-DS Dependent Patterns.
       whitelistPatterns: [/^bg/, /^text/, /:?-?m[xy]?-/, /:?p[xy]?-/],


### PR DESCRIPTION
Makes tailwind purge aware of Drupal templates inside app/particle/templates

I need to test for this a bit more but it seems to meet the requirements. 
That said you either run:
npm run build: drupal - for webpack to find what new tailwind classes to add to the bundle or
npm run dev: drupal so it will load the whole set of tailwind classes. This does not ensure it works on the production build.

As seen in the pictures below. Tailwind purge is super useful. If it was not due to it we will end up going from **139kb** to **1.9mb** or something crazy like that. 
https://tailwindcss.com/docs/controlling-file-size
![Screen Shot 2020-10-30 at 11 53 40 AM](https://user-images.githubusercontent.com/39039024/97731473-8c451700-1aab-11eb-8d7e-ba39aa1c8c46.png)
![Screen Shot 2020-10-30 at 11 50 11 AM](https://user-images.githubusercontent.com/39039024/97731482-8ea77100-1aab-11eb-8072-426ed5436624.png)


The way that I whitelisted the folder preserves purging so our app.css file size remains small.
