### PR TITLE
Feature/utc 1203 library db box styles

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--block--utc-library-embed-widget.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--block--utc-library-embed-widget.html.twig
@@ -28,11 +28,12 @@
 {# hack to fix select box on EndNote embed - this will be fixed if this is approved to push to Prod #}
 <style>
   .utclib-embed-content select{
-    width: 100%;
+    width: 100%; 
   }
 </style>
 
 <div{{attributes}}>
+<div class="utclib-embed--{{ label|clean_class }}">
 	{{ title_prefix }}
 	{% if label %}
 		<h2{{title_attributes}}>
@@ -47,5 +48,5 @@
       {% endautoescape %}
     </div>
 	{% endblock %}
-
+</div>
 </div>

--- a/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utclib_guides.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utclib_guides.css
@@ -1,5 +1,6 @@
+/* styles for research guide list */
 #views-exposed-form-utclib-guides-block-1 .form-select,
-#views-exposed-form-utclib-guides-block-1 input[type=text] {
+#views-exposed-form-utclib-guides-block-1 input[type='text'] {
   height: 50px;
   width: 100%;
   border: 2px solid;
@@ -67,4 +68,61 @@
   border-left: 5px solid #fdb736;
   @apply bg-gray-100;
   font-weight: 600;
+}
+
+/* new databases box */
+
+.utclib-embed--new-databases h2.block__title {
+  display: block;
+  @apply text-utc-new-blue-500;
+  font-family: 'Exo', 'Helvetica Neue', sans-serif;
+  text-transform: none;
+  @apply bg-gray-200;
+  padding: 0.75rem 1.25rem;
+  margin: 0;
+  font-weight: 700;
+  font-size: 1.15rem;
+}
+
+.utclib-embed--new-databases {
+  @apply bg-white;
+  word-wrap: break-word;
+  border: 0;
+  border-radius: 0;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1),
+    0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  margin-bottom: 2rem;
+}
+
+.utclib-embed--new-databases .utclib-embed-content {
+  padding: 0.9rem;
+}
+
+.s-lg-link-list {
+  list-style-type: none;
+  padding-left: 0.5rem;
+  margin-bottom: 0;
+}
+ul.s-lg-link-list li {
+  border-bottom: 1px solid lightgrey;
+  margin-bottom: 0.5rem;
+  padding-bottom: .5rem;
+}
+
+ul.s-lg-link-list li a {
+  font-weight: bold;
+  font-size: 1rem;
+  @apply text-utc-new-blue-500;
+  line-height: 1.25;
+  margin-bottom: .5rem;
+}
+
+.s-lg-link-desc,
+.s-lg-link-desc a {
+  font-size: .9rem !important;
+}
+
+ul.s-lg-link-list li:last-child {
+  border-bottom: 0px;
+  margin-bottom: 0rem;
 }


### PR DESCRIPTION
Edits to the theme for the new databases box:

<img width="419" alt="Screen Shot 2020-11-09 at 3 41 53 PM" src="https://user-images.githubusercontent.com/50490141/98596134-0001d380-22a5-11eb-8525-6ab5522559d0.png">

I added a way to add a unique css class for each box based on the box label, but now that I'm thinking on it...that may be too easily broken. Renaming the box will destroy the code. Maybe a field should be added to the box config where a custom wrapper class can be added? LMK what you think.