### PR TITLE
fix/UTC-1214-fix employee block width

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_employee.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_employee.css
@@ -36,6 +36,14 @@
     width: 100%;
   }
 }
+
+/* fix card layout for cards placed in side columns */
+.themag-layout--twocol-section
+  .themag-layout__region--first
+  .employee-card__container--default {
+  width: 100%;
+  margin: .75rem 0;
+}
 /* hover state for teaser cards if linked */
 a .employee-card--utc-small-teaser-card:hover {
   @apply bg-gray-200;
@@ -65,7 +73,7 @@ a .employee-card--utc-small-teaser-card:hover {
 }
 
 .employee-card--utc-wide,
-.employee-card--full, {
+.employee-card--full {
   flex-direction: row;
 }
 
@@ -77,12 +85,10 @@ a .employee-card--utc-small-teaser-card:hover {
   flex: 0 1 35%;
 }
 /* makes images stretch to full size of container in automated field classes */
-.employee-card--utc-wide img,
-.employee-card--utc-wide .employee-image .field,
-.employee-card--utc-wide .employee-image .field__item,
-.employee-card--full img,
-.employee-card--full .employee-image .field,
-.employee-card--full .employee-image .field__item {
+.employee-card img,
+.employee-card .employee-image .field,
+.employee-card .employee-image .field__item
+ {
   height: 100%;
   width: 100%;
   object-fit: cover;


### PR DESCRIPTION
Fixes the width issue for employee blocks placed in first column of a two column layout.

<img width="1124" alt="Screen Shot 2020-11-10 at 10 56 05 AM" src="https://user-images.githubusercontent.com/50490141/98697867-61787f80-2343-11eb-8548-442cf1d4cf73.png">
