### PR TITLE
fix/UTC-1228-fix-button-width

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc-button-group.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc-button-group.css
@@ -12,10 +12,10 @@
   margin-top: auto;
   margin-bottom: auto;
   display: inline-flex;
-  min-width: 100%;
+  width: 100%;
   box-sizing: border-box;
   justify-content: center;
   text-align: center;
   align-items: center;
   vertical-align: middle;
-}
+} 


### PR DESCRIPTION
Issue: https://github.com/UTCWeb/utccloud/issues/1228

This isn't a perfect fix, but it fixes the spacing on larger screens. On midsized screens, the text still overflows. I'm not exactly sure the best way to fix this without compromising the symmetry of the blocks. Flex-wrap would be an option...but then alignment for double rows would be compromised? Someone might want to revisit these at some point in general to see if the grid template in particle could be extended in this block.

**Wide Screens:**
<img width="1451" alt="Screen Shot 2020-11-10 at 4 15 42 PM" src="https://user-images.githubusercontent.com/50490141/98735398-4ae91d00-2371-11eb-858a-203820e38bda.png">

**Smaller Screens:**
<img width="1139" alt="Screen Shot 2020-11-10 at 4 15 52 PM" src="https://user-images.githubusercontent.com/50490141/98735389-47ee2c80-2371-11eb-9114-a110138aa401.png">


In cases like this, the best solution might be to decrease the button size one step or use more rows of buttons.

