### PR TITLE
Fix/lib events styels

### DIFF
--- a/source/default/_patterns/00-protons/index.js
+++ b/source/default/_patterns/00-protons/index.js
@@ -30,6 +30,7 @@ import './legacy/css/components/UTC-custom-blocks/_utclib_primo_search.css';
 import './legacy/css/components/UTC-custom-blocks/_utclib_help_btn.css';
 import './legacy/css/components/UTC-custom-blocks/_utclib_events_feed.css';
 import './legacy/css/components/UTC-custom-blocks/_utclib_guides.css';
+import './legacy/css/components/UTC-custom-blocks/_utclib_events.css';
 import './legacy/css/components/navigation/_breadcrumb.css';
 import './legacy/css/components/navigation/_footer-menu.css';
 

--- a/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utclib_events.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utclib_events.css
@@ -34,9 +34,8 @@
     flex-direction: column;
     padding: .5rem .5rem;
     flex: 0 1 60%;
-    font-size: 15px;
+    font-size: 16px;
     justify-content: center;
-    font-weight: 600;
 }
 
 .qtip-bootstrap .event-overview .event-image {

--- a/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utclib_events.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utclib_events.css
@@ -1,0 +1,60 @@
+.qtip {
+  max-width: 400px;
+  min-width: 200px;
+}
+
+.qtip .qtip-title {
+    line-height: 1.5rem;
+    font-weight: 600;
+}
+
+.qtip-bootstrap {
+  border-radius: 0;
+}
+
+.qtip-bootstrap .qtip-content {
+  padding: 0px;
+}
+
+.qtip-bootstrap .qtip-titlebar {
+  font-size: 1rem;
+}
+
+.qtip-bootstrap .btn {
+  display: block;
+}
+
+.qtip-bootstrap .event-overview {
+  display: flex;
+  flex-direction: row;
+}
+
+.qtip-bootstrap .event-overview .event-info {
+    display: flex;
+    flex-direction: column;
+    padding: .5rem .5rem;
+    flex: 0 1 60%;
+    font-size: 15px;
+    justify-content: center;
+    font-weight: 600;
+}
+
+.qtip-bootstrap .event-overview .event-image {
+  flex: 0 1 40%;
+}
+
+.qtip-bootstrap .event-overview .event-image img {
+  height: 100%;
+  width: 100%;
+  object-fit: cover;
+}
+
+.qtip-bootstrap .event-description {
+  @apply bg-gray-200;
+  margin: 0;
+  padding: .5rem 1rem;
+}
+
+.qtip-bootstrap .event-description .btn {
+    margin-top: 1rem;
+}


### PR DESCRIPTION
Style updates for the library event view, there's a bit of config I'll add in utccloud to go with this.

<img width="1676" alt="Screen Shot 2020-11-12 at 4 25 41 PM" src="https://user-images.githubusercontent.com/50490141/98999092-2c1b8f80-2505-11eb-84a8-428d476de757.png">
