### PR TITLE
UTC-137: updated the padding to match GT

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/global.css
+++ b/source/default/_patterns/00-protons/legacy/css/global.css
@@ -134,7 +134,7 @@ div.site-alert div.severity-high {
   margin-bottom: 0em;
 }
 div.site-alert div.text {
-  padding: 10px 10px 10px 10px;
+  padding: 0.3rem;
   margin: 0px;
   font-size: 18px;
 }


### PR DESCRIPTION
After looking at partner/competing universities it seems good to reduce the padding on the COVID banner line.