### PR TITLE
UTC-187-Particle primary--button style update

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/components/buttons/_buttons.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/buttons/_buttons.css
@@ -40,6 +40,7 @@
 .btn-primary:focus,
 .btn-dark:focus {
   box-shadow: inset 0px 0px 8px 2px rgba(0, 0, 0, 0.2);
+  border: 0;
 }
 
 .btn--yellow,
@@ -155,6 +156,7 @@
 .btn-light {
   @apply bg-gray-300;
   @apply text-utc-new-blue-500;
+  border: 0;
 }
 
 .btn--lightblue:hover,

--- a/source/default/_patterns/01-atoms/form-element/_input.twig
+++ b/source/default/_patterns/01-atoms/form-element/_input.twig
@@ -20,9 +20,9 @@
 {# Non-Input Form Types #}
 {% set form_type_classes = {
   input: 'form-input',
-  button: 'form-input button button--primary button--sm',
-  submit: 'form-input button button--primary button--sm',
-  reset: 'form-input button button--secondary button--sm',
+  button: 'form-input button btn--lightblue button--sm',
+  submit: 'form-input button btn--lightblue button--sm',
+  reset: 'form-input button btn--lightblue button--sm',
   checkbox: 'form-checkbox',
   color: 'form-color',
   radio: 'form-radio',


### PR DESCRIPTION
Closes Issue #187 

## Issue Description

Particle !important changes some submit buttons across site from grey to bright blue:

**Before**
<img width="1010" alt="Screen Shot 2021-03-03 at 6 10 47 AM" src="https://user-images.githubusercontent.com/50490141/109803879-9741bc80-7bef-11eb-9cf3-7eef8c872ae7.png">

**After**
<img width="309" alt="Screen Shot 2021-03-01 at 10 36 49 PM" src="https://user-images.githubusercontent.com/50490141/109803902-9f016100-7bef-11eb-948b-de02bd0560d0.png">


## Summary of Changes

- I updated the _input particle classes to use btn--lightblue. We could choose another btn class in the css, if needed. The root button class is still coming from particle css (font size, padding, etc.).

<img width="1010" alt="Screen Shot 2021-03-03 at 7 08 41 AM" src="https://user-images.githubusercontent.com/50490141/109804119-e4be2980-7bef-11eb-8562-8050586e2361.png">
<img width="1010" alt="Screen Shot 2021-03-03 at 7 04 31 AM" src="https://user-images.githubusercontent.com/50490141/109804139-ea1b7400-7bef-11eb-8091-acef9a015561.png">

- Contrast is a bit low, perhaps on layout editor buttons vs. background. But, difficult to modify just these vs. everything else on the site.
<img width="1010" alt="Screen Shot 2021-03-03 at 7 05 48 AM" src="https://user-images.githubusercontent.com/50490141/109804093-de2fb200-7bef-11eb-8ae6-0323017572e1.png">

