### PR TITLE
Feature/utc 192 banner block

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
@@ -49,6 +49,7 @@
 				{{ utc_hero.hero_image }} 
 				</div>
 			{% endif %}
+			<div>
 				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-3 lg:mx-8 p-4 z-30 self-end">
 		{% else %}
 		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-rows-utchero lg:grid-cols-utcheroright grid-flow-row lg:mb-4 2xl:grid-cols-utcherolargeright text-center">
@@ -57,6 +58,7 @@
 				{{ utc_hero.hero_image }}
 				</div>
 			{% endif %}
+			<div>
 				<div class="2xl:col-start-2 lg:col-start-2 lg:col-end-2 lg:row-start-2 lg:row-end-3 lg:mx-8 p-4 col-span-1 z-30 self-end">
 		{% endif %}
 			{% if utc_hero.hero_tag %}
@@ -98,6 +100,7 @@
 			<div class="w-full h-full bg-cover bg-center z-10 md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-3" style="background-image: url({{ utc_hero.hero_bg }})">
 			
 				<div class="h-full w-full bg-opacity-90 {{ bg_color }}"></div>
+				</div>
 				</div>
 
 

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
@@ -2,7 +2,8 @@
 {#
 /**
  * @file Card Grid!
- * Implements a grid of cards using Bootstrap layout.
+ * Implements a hero block in dark blue
+ *
  *
  * Available variables:
  */
@@ -10,61 +11,88 @@
  * This template pulls in the variables to add to the cards. 
  * References the block--utc-card-base.html.twig to create the individual cards in this grid.
 #}
- 
+
 {% block content %}
 	{% set rendered_content = content|render %}
 	{# Sets variable to trigger content render array. #}
-
-	{# set variables for card content based on Drupal input #}
 	{# hero_button_link: content.field_hero_button|field_value, #}
+	{% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %}
 	{% set utc_hero = {
+	hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_image_select)["#object"].field_image_url.value,
+	hero_align: content["#block_content"].field_hero_align.0.value,
+	hero_color: content["#block_content"].field_hero_color.0.value,
 	hero_tag: content.field_hero_tag|field_value,
     hero_title: content.field_hero_title|field_value,
     hero_image: content.field_utc_media|field_value,
-    hero_text: content.field_hero_body|field_value,
+    hero_text: content.field_hero_text|field_value,
     hero_button_text: content.field_hero_button.0['#title'],
     hero_button_url: content.field_hero_button.0['#url'],
     } %}
+	{# Sets colors for hero content depending on selection #}
+	{% if utc_hero.hero_color == 'Dark Blue' %}
+	{% set title_color = 'lg:text-white' %}
+	{% set body_color = 'lg:text-white' %}
+	{% set bg_color = 'bg-utc-new-blue-500' %}
+	{% else %}
+	{% set title_color = 'text-utc-new-blue-500' %}
+	{% set body_color = 'text-base' %}
+	{% set bg_color = 'bg-gray-400' %}
+	{% endif %}
 
-	<div class="grid grid-cols-1 lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-4 2xl:grid-cols-utcherolarge grid-flow-row lg:mb-4 text-center"> 
-		{% if utc_hero.hero_image %}
-				<div class="2xl:col-start-2 lg:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto col-span-1 z-30">{{ utc_hero.hero_image }} </div>
+
+
+		 
+		{% if utc_hero.hero_align == 'Left' %}
+		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-8 lg:gap-x-12 grid-flow-row lg:mb-4 2xl:grid-cols-utcherolarge text-center">
+			{% if utc_hero.hero_image %}
+				<div class="2xl:col-start-2 lg:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto col-span-1 z-30">
+				{{ utc_hero.hero_image }} 
+				</div>
+			{% endif %}
+				<div class="2xl:ml-0 lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:m-auto p-4 z-30">
+		{% else %}
+		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-8 lg:gap-x-12 grid-flow-row lg:mb-4 2xl:grid-cols-utcherolargeright text-center">
+			{% if utc_hero.hero_image %}
+				<div class="2xl:ml-0 lg:col-start-3 lg:col-end-5 2xl:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto z-30">
+				{{ utc_hero.hero_image }}
+				</div>
+			{% endif %}
+				<div class="2xl:col-start-2 lg:col-start-2 lg:col-end-2 lg:row-start-1 lg:row-end-4 lg:m-auto p-4 col-span-1 z-30">
 		{% endif %}
-
-
-		<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-3 col-span-1 m-auto z-30"> 	
 			{% if utc_hero.hero_tag %}
-					<h4 class="text-center uppercase" >
-						{{ utc_hero.hero_tag}}
-					</h4>
+				<p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">
+					{{ utc_hero.hero_tag }}
+				</p>
+				<hr class="border-t-3 border-utc-new-gold-500 my-2 w-20" />
 			{% endif %}
 			{% if utc_hero.hero_title %}
-					<h2 class="text-center" >
-						{{ utc_hero.hero_title }}
-					</h2>
+				<h2 class="text-left {{ title_color }}">
+					{{ utc_hero.hero_title }}
+				</h2>
 			{% endif %}
-		</div>
-
-		<div class="lg:col-start-3 lg:col-end-4 lg:row-start-3 lg:row-end-4 col-span-1 m-auto z-30">
-		{% if utc_hero.hero_text %}
-					<h3 class="text-center">
-						{{ utc_hero.hero_text}}
-					</h3>
+			{% if utc_hero.hero_text %}
+				<p class="text-left text-lg text-base {{ body_color }}">
+					{{ utc_hero.hero_text}}
+				</p>
 			{% endif %}
 			{% if utc_hero.hero_button_url %}
 				{% if utc_hero.hero_button_text %}
-					<p class="mt-4">
-					<a href="{{ utc_hero.hero_button_url}}" class="text-center hover:bg-white py-2 px-4 border border-gray-400" aria-label="Read the release">
-					 Learn more</a><p>
+					<p class="mt-5 text-right">
+						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out {{ body_color }} hover:text-utc-new-blue-500 hover:bg-white transform hover:scale-105 py-2 px-4 border border-white" aria-label="Read the release">
+							Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i></a>
+					</p>
+					<p>
+					{% endif %}
 				{% endif %}
-			{% endif %}
-		</div>	
-		<div class="lg:col-start-1 lg:col-end-5 lg:row-start-1 lg:row-end-3 bg-gray-400 h-full w-full z-10"> 	
-		</div>	
+				</div>
 
-	</div>
-
-
+			<div class="w-full h-full bg-cover bg-center z-10 md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-4" style="background-image: url({{ utc_hero.hero_bg }})">
+			
+				<div class="h-full w-full bg-opacity-90 {{ bg_color }}"></div>
+				</div>
 
 
-{% endblock %}
+		</div>
+
+
+	{% endblock %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
@@ -36,28 +36,28 @@
 	{% else %}
 	{% set title_color = 'text-utc-new-blue-500' %}
 	{% set body_color = 'text-base' %}
-	{% set bg_color = 'bg-gray-400' %}
+	{% set bg_color = 'bg-utc-new-blue-300' %}
 	{% endif %}
 
 
 
 		 
 		{% if utc_hero.hero_align == 'Left' %}
-		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-8 lg:gap-x-12 grid-flow-row lg:mb-4 2xl:grid-cols-utcherolarge text-center">
+		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-rows-utchero lg:grid-cols-utchero grid-flow-row lg:mb-4 2xl:grid-cols-utcherolarge text-center">
 			{% if utc_hero.hero_image %}
-				<div class="2xl:col-start-2 lg:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto col-span-1 z-30">
+				<div class="2xl:col-start-2 lg:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto lg:mt-8 col-span-1 z-30">
 				{{ utc_hero.hero_image }} 
 				</div>
 			{% endif %}
-				<div class="2xl:ml-0 lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:m-auto p-4 z-30">
+				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-3 lg:mx-8 p-4 z-30 self-end">
 		{% else %}
-		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-8 lg:gap-x-12 grid-flow-row lg:mb-4 2xl:grid-cols-utcherolargeright text-center">
+		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-rows-utchero lg:grid-cols-utcheroright grid-flow-row lg:mb-4 2xl:grid-cols-utcherolargeright text-center">
 			{% if utc_hero.hero_image %}
-				<div class="2xl:ml-0 lg:col-start-3 lg:col-end-5 2xl:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto z-30">
+				<div class="lg:col-start-3 lg:col-end-5 2xl:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto lg:mt-8 z-30">
 				{{ utc_hero.hero_image }}
 				</div>
 			{% endif %}
-				<div class="2xl:col-start-2 lg:col-start-2 lg:col-end-2 lg:row-start-1 lg:row-end-4 lg:m-auto p-4 col-span-1 z-30">
+				<div class="2xl:col-start-2 lg:col-start-2 lg:col-end-2 lg:row-start-2 lg:row-end-3 lg:mx-8 p-4 col-span-1 z-30 self-end">
 		{% endif %}
 			{% if utc_hero.hero_tag %}
 				<p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">
@@ -70,23 +70,32 @@
 					{{ utc_hero.hero_title }}
 				</h2>
 			{% endif %}
+			</div>
+			{% if utc_hero.hero_align == 'Left' %}
+			<div class="lg:col-start-3 lg:col-end-4 lg:row-start-3 lg:row-end-4 lg:mx-8 p-4 z-30">
+			{% else %}
+			<div class="2xl:col-start-2 lg:col-start-2 lg:col-end-2 lg:row-start-3 lg:row-end-4 lg:mx-8 p-4 col-span-1 z-30">
+			{% endif %}
+			<div class="flex flex-column w-0" style="min-width: 38rem;">
 			{% if utc_hero.hero_text %}
-				<p class="text-left text-lg text-base {{ body_color }}">
+				<p class="text-left text-lg text-base">
 					{{ utc_hero.hero_text}}
 				</p>
 			{% endif %}
 			{% if utc_hero.hero_button_url %}
 				{% if utc_hero.hero_button_text %}
-					<p class="mt-5 text-right">
-						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out {{ body_color }} hover:text-utc-new-blue-500 hover:bg-white transform hover:scale-105 py-2 px-4 border border-white" aria-label="Read the release">
+					<p class="mt-6 self-end">
+						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out text-base hover:bg-utc-new-blue-500 hover:text-white transform hover:scale-105 py-2 px-4 border border-utc-new-blue-500" aria-label="Read the release">
 							Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i></a>
 					</p>
-					<p>
 					{% endif %}
 				{% endif %}
+
+		</div>
+
 				</div>
 
-			<div class="w-full h-full bg-cover bg-center z-10 md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-4" style="background-image: url({{ utc_hero.hero_bg }})">
+			<div class="w-full h-full bg-cover bg-center z-10 md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-3" style="background-image: url({{ utc_hero.hero_bg }})">
 			
 				<div class="h-full w-full bg-opacity-90 {{ bg_color }}"></div>
 				</div>

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
@@ -43,23 +43,23 @@
 
 		 
 		{% if utc_hero.hero_align == 'Left' %}
-		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-rows-utchero lg:grid-cols-utchero grid-flow-row lg:mb-4 2xl:grid-cols-utcherolarge text-center">
+		<div class="grid grid-cols-1 lg:grid-rows-utchero lg:grid-cols-utchero md:grid-flow-col lg:grid-flow-row lg:mb-4 2xl:grid-cols-utcherolarge text-center">
 			{% if utc_hero.hero_image %}
-				<div class="2xl:col-start-2 lg:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto lg:mt-8 col-span-1 z-30">
+				<div class="2xl:col-start-2 lg:col-start-1 md:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto lg:mt-8 col-span-1 z-30">
 				{{ utc_hero.hero_image }} 
 				</div>
 			{% endif %}
-			<div>
-				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-3 lg:mx-8 p-4 z-30 self-end">
+
+				<div class="lg:col-start-3 md:col-start-1 lg:col-end-4 lg:row-start-2 lg:row-end-3 lg:mx-8 p-4 pb-0 lg:pb-4 z-30 self-end">
 		{% else %}
-		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-rows-utchero lg:grid-cols-utcheroright grid-flow-row lg:mb-4 2xl:grid-cols-utcherolargeright text-center">
+		<div class="grid grid-cols-1 lg:grid-rows-utchero lg:grid-cols-utcheroright lg:grid-flow-row md:grid-flow-col lg:mb-4  2xl:grid-cols-utcherolargeright text-center">
 			{% if utc_hero.hero_image %}
-				<div class="lg:col-start-3 lg:col-end-5 2xl:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto lg:mt-8 z-30">
+				<div class="lg:col-start-3 lg:col-end-5 md:col-start-1 2xl:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto lg:mt-8 z-30">
 				{{ utc_hero.hero_image }}
 				</div>
 			{% endif %}
-			<div>
-				<div class="2xl:col-start-2 lg:col-start-2 lg:col-end-2 lg:row-start-2 lg:row-end-3 lg:mx-8 p-4 col-span-1 z-30 self-end">
+		
+				<div class="2xl:col-start-2 lg:col-start-2 md:col-start-1 lg:col-end-2 lg:row-start-2 lg:row-end-3 lg:mx-8 p-4 pb-0 lg:pb-4 col-span-1 z-30 self-end">
 		{% endif %}
 			{% if utc_hero.hero_tag %}
 				<p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">
@@ -74,11 +74,10 @@
 			{% endif %}
 			</div>
 			{% if utc_hero.hero_align == 'Left' %}
-			<div class="lg:col-start-3 lg:col-end-4 lg:row-start-3 lg:row-end-4 lg:mx-8 p-4 z-30">
+			<div class="lg:col-start-3 md:col-start-1 lg:col-end-4 lg:row-start-3 lg:row-end-4 lg:mx-8 p-4 z-30 pt-0 lg:pt-4">
 			{% else %}
-			<div class="2xl:col-start-2 lg:col-start-2 lg:col-end-2 lg:row-start-3 lg:row-end-4 lg:mx-8 p-4 col-span-1 z-30">
+			<div class="2xl:col-start-2 lg:col-start-2 md:col-start-1 lg:col-end-2 lg:row-start-3 lg:row-end-4 lg:mx-8 p-4 col-span-1 z-30 pt-0 lg:pt-4">
 			{% endif %}
-			<div class="flex flex-column w-0" style="min-width: 38rem;">
 			{% if utc_hero.hero_text %}
 				<p class="text-left text-lg text-base">
 					{{ utc_hero.hero_text}}
@@ -86,14 +85,12 @@
 			{% endif %}
 			{% if utc_hero.hero_button_url %}
 				{% if utc_hero.hero_button_text %}
-					<p class="mt-6 self-end">
+					<p class="mt-6 xl:mr-16 text-right">
 						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out text-base hover:bg-utc-new-blue-500 hover:text-white transform hover:scale-105 py-2 px-4 border border-utc-new-blue-500" aria-label="Read the release">
 							Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i></a>
 					</p>
 					{% endif %}
 				{% endif %}
-
-		</div>
 
 				</div>
 
@@ -101,7 +98,7 @@
 			
 				<div class="h-full w-full bg-opacity-90 {{ bg_color }}"></div>
 				</div>
-				</div>
+		
 
 
 		</div>

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
@@ -36,28 +36,28 @@
 	{% else %}
 	{% set title_color = 'text-utc-new-blue-500' %}
 	{% set body_color = 'text-base' %}
-	{% set bg_color = 'bg-gray-400' %}
+	{% set bg_color = 'bg-utc-new-blue-300' %}
 	{% endif %}
 
 
 
 		 
 		{% if utc_hero.hero_align == 'Left' %}
-		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-8 lg:gap-x-12 grid-flow-row lg:mb-4 2xl:grid-cols-utcherolarge text-center">
+		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-8 grid-flow-row lg:mb-4 2xl:grid-cols-utcherolarge text-center">
 			{% if utc_hero.hero_image %}
 				<div class="2xl:col-start-2 lg:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto col-span-1 z-30">
 				{{ utc_hero.hero_image }} 
 				</div>
 			{% endif %}
-				<div class="2xl:ml-0 lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:m-auto p-4 z-30">
+				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:my-auto lg:mx-8 p-4 z-30">
 		{% else %}
-		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-8 lg:gap-x-12 grid-flow-row lg:mb-4 2xl:grid-cols-utcherolargeright text-center">
+		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-8 grid-flow-row lg:mb-4 2xl:grid-cols-utcherolargeright text-center">
 			{% if utc_hero.hero_image %}
-				<div class="2xl:ml-0 lg:col-start-3 lg:col-end-5 2xl:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto z-30">
+				<div class="lg:col-start-3 lg:col-end-5 2xl:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto z-30">
 				{{ utc_hero.hero_image }}
 				</div>
 			{% endif %}
-				<div class="2xl:col-start-2 lg:col-start-2 lg:col-end-2 lg:row-start-1 lg:row-end-4 lg:m-auto p-4 col-span-1 z-30">
+				<div class="2xl:col-start-2 lg:col-start-2 lg:col-end-2 lg:row-start-1 lg:row-end-4 lg:my-auto lg:mx-8 p-4 col-span-1 z-30">
 		{% endif %}
 			{% if utc_hero.hero_tag %}
 				<p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
@@ -18,7 +18,8 @@
 	{# set variables for card content based on Drupal input #}
 	{# hero_button_link: content.field_hero_button|field_value, #}
 	{% set utc_hero = {
-	hero_bg: 'https://www.utc.edu/about/buildings/images/exterior-spaces-header.jpg',
+	hero_bg: content.field_hero_background_image|field_value,
+	hero_align: content["#block_content"].field_hero_align.0.value,
 	hero_tag: content.field_hero_tag|field_value,
     hero_title: content.field_hero_title|field_value,
     hero_image: content.field_utc_media|field_value,
@@ -27,16 +28,29 @@
     hero_button_url: content.field_hero_button.0['#url'],
     } %}
 
-		<div class="grid grid-cols-1 lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-8 lg:gap-x-12  grid-flow-row lg:mb-4 2xl:grid-cols-utcherolarge text-center"> {% if utc_hero.hero_image %}
-			<div class="2xl:col-start-2 lg:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto col-span-1 z-30">{{ utc_hero.hero_image }}
-			</div>
+
+
+		 
+		{% if utc_hero.hero_align == 'Left' %}
+		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-8 lg:gap-x-12 grid-flow-row lg:mb-4 2xl:grid-cols-utcherolarge text-center">
+			{% if utc_hero.hero_image %}
+				<div class="2xl:col-start-2 lg:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto col-span-1 z-30">
+				{{ utc_hero.hero_image }} 
+				</div>
+			{% endif %}
+				<div class="2xl:ml-0 lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:m-auto m-2 z-30">
+		{% else %}
+		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-8 lg:gap-x-12 grid-flow-row lg:mb-4 2xl:grid-cols-utcherolargeright text-center">
+			{% if utc_hero.hero_image %}
+				<div class="2xl:ml-0 lg:col-start-3 lg:col-end-5 2xl:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto z-30">
+				{{ utc_hero.hero_image }}
+				</div>
+			{% endif %}
+				<div class="2xl:col-start-2 lg:col-start-2 lg:col-end-2 lg:row-start-1 lg:row-end-4 lg:m-auto m-2 col-span-1 z-30">
 		{% endif %}
-
-
-		<div class="2xl:ml-0 lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:m-auto m-2 z-30">
 			{% if utc_hero.hero_tag %}
 				<p class="text-left font-semibold tracking-wide uppercase text-lg">
-					{{ utc_hero.hero_tag }}
+					{{ utc_hero.hero_tag }} {{ utc_hero.hero_align }}
 				</p>
 				<hr class="border-t-3 border-utc-new-gold-500 my-2 w-20" />
 			{% endif %}
@@ -59,12 +73,13 @@
 					<p>
 					{% endif %}
 				{% endif %}
+				</div>
 
-			</div>
-			<div class=""></div>
-			<div class="w-full h-full bg-cover bg-center z-10 lg:col-start-1 lg:col-end-5 lg:row-start-1 lg:row-end-4" style="background-image: url({{ utc_hero.hero_bg }})">
-				<div class="h-full w-full bg-gray-400 bg-opacity-95"></div>
-			</div>
+			<div class="w-full h-full bg-cover bg-center z-10 md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-4" style="background-image: url({{ utc_hero.hero_bg }})">
+			
+				<div class="h-full w-full bg-gray-400 bg-opacity-90"></div>
+				</div>
+
 
 		</div>
 

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
@@ -30,8 +30,8 @@
     } %}
 	{# Sets colors for hero content depending on selection #}
 	{% if utc_hero.hero_color == 'Dark Blue' %}
-	{% set title_color = 'text-white' %}
-	{% set body_color = 'text-white' %}
+	{% set title_color = 'lg:text-white' %}
+	{% set body_color = 'lg:text-white' %}
 	{% set bg_color = 'bg-utc-new-blue-500' %}
 	{% else %}
 	{% set title_color = 'text-utc-new-blue-500' %}
@@ -49,7 +49,7 @@
 				{{ utc_hero.hero_image }} 
 				</div>
 			{% endif %}
-				<div class="2xl:ml-0 lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:m-auto m-2 z-30">
+				<div class="2xl:ml-0 lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:m-auto p-4 z-30">
 		{% else %}
 		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-8 lg:gap-x-12 grid-flow-row lg:mb-4 2xl:grid-cols-utcherolargeright text-center">
 			{% if utc_hero.hero_image %}
@@ -57,7 +57,7 @@
 				{{ utc_hero.hero_image }}
 				</div>
 			{% endif %}
-				<div class="2xl:col-start-2 lg:col-start-2 lg:col-end-2 lg:row-start-1 lg:row-end-4 lg:m-auto m-2 col-span-1 z-30">
+				<div class="2xl:col-start-2 lg:col-start-2 lg:col-end-2 lg:row-start-1 lg:row-end-4 lg:m-auto p-4 col-span-1 z-30">
 		{% endif %}
 			{% if utc_hero.hero_tag %}
 				<p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">
@@ -71,7 +71,7 @@
 				</h2>
 			{% endif %}
 			{% if utc_hero.hero_text %}
-				<p class="text-left text-lg {{ body_color }}">
+				<p class="text-left text-lg text-base {{ body_color }}">
 					{{ utc_hero.hero_text}}
 				</p>
 			{% endif %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
@@ -43,7 +43,7 @@
 
 		 
 		{% if utc_hero.hero_align == 'Left' %}
-		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-8 grid-flow-row lg:mb-4 2xl:grid-cols-utcherolarge text-center">
+		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-8 lg:grid-flow-row lg:mb-4 2xl:grid-cols-utcherolarge text-center">
 			{% if utc_hero.hero_image %}
 				<div class="2xl:col-start-2 lg:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto col-span-1 z-30">
 				{{ utc_hero.hero_image }} 
@@ -77,8 +77,8 @@
 			{% endif %}
 			{% if utc_hero.hero_button_url %}
 				{% if utc_hero.hero_button_text %}
-					<p class="mt-5 text-right">
-						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out {{ body_color }} hover:text-utc-new-blue-500 hover:bg-white transform hover:scale-105 py-2 px-4 border border-white" aria-label="Read the release">
+					<p class="mt-6 lg:mr-16 text-right">
+						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out {{ body_color }} hover:text-utc-new-blue-500 hover:bg-white transform hover:scale-105 py-2 px-4 border border-utc-new-blue-500 lg:border-white" aria-label="Read the release">
 							Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i></a>
 					</p>
 					<p>

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
@@ -2,7 +2,8 @@
 {#
 /**
  * @file Card Grid!
- * Implements a grid of cards using Bootstrap layout.
+ * Implements a hero block in dark blue
+ *
  *
  * Available variables:
  */
@@ -14,19 +15,29 @@
 {% block content %}
 	{% set rendered_content = content|render %}
 	{# Sets variable to trigger content render array. #}
-
-	{# set variables for card content based on Drupal input #}
 	{# hero_button_link: content.field_hero_button|field_value, #}
+	{% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %}
 	{% set utc_hero = {
-	hero_bg: content.field_hero_background_image|field_value,
+	hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_image_select)["#object"].field_image_url.value,
 	hero_align: content["#block_content"].field_hero_align.0.value,
+	hero_color: content["#block_content"].field_hero_color.0.value,
 	hero_tag: content.field_hero_tag|field_value,
     hero_title: content.field_hero_title|field_value,
     hero_image: content.field_utc_media|field_value,
-    hero_text: content.field_hero_body|field_value,
+    hero_text: content.field_hero_text|field_value,
     hero_button_text: content.field_hero_button.0['#title'],
     hero_button_url: content.field_hero_button.0['#url'],
     } %}
+	{# Sets colors for hero content depending on selection #}
+	{% if utc_hero.hero_color == 'Dark Blue' %}
+	{% set title_color = 'text-white' %}
+	{% set body_color = 'text-white' %}
+	{% set bg_color = 'bg-utc-new-blue-500' %}
+	{% else %}
+	{% set title_color = 'text-utc-new-blue-500' %}
+	{% set body_color = 'text-base' %}
+	{% set bg_color = 'bg-gray-400' %}
+	{% endif %}
 
 
 
@@ -49,25 +60,25 @@
 				<div class="2xl:col-start-2 lg:col-start-2 lg:col-end-2 lg:row-start-1 lg:row-end-4 lg:m-auto m-2 col-span-1 z-30">
 		{% endif %}
 			{% if utc_hero.hero_tag %}
-				<p class="text-left font-semibold tracking-wide uppercase text-lg">
-					{{ utc_hero.hero_tag }} {{ utc_hero.hero_align }}
+				<p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">
+					{{ utc_hero.hero_tag }}
 				</p>
 				<hr class="border-t-3 border-utc-new-gold-500 my-2 w-20" />
 			{% endif %}
 			{% if utc_hero.hero_title %}
-				<h2 class="text-left">
+				<h2 class="text-left {{ title_color }}">
 					{{ utc_hero.hero_title }}
 				</h2>
 			{% endif %}
 			{% if utc_hero.hero_text %}
-				<div class="text-left text-base">
+				<p class="text-left text-lg {{ body_color }}">
 					{{ utc_hero.hero_text}}
-				</div>
+				</p>
 			{% endif %}
 			{% if utc_hero.hero_button_url %}
 				{% if utc_hero.hero_button_text %}
 					<p class="mt-5 text-right">
-						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out hover:bg-white transform hover:scale-105 py-2 px-4 border border-white" aria-label="Read the release">
+						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out {{ body_color }} hover:text-utc-new-blue-500 hover:bg-white transform hover:scale-105 py-2 px-4 border border-white" aria-label="Read the release">
 							Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i></a>
 					</p>
 					<p>
@@ -77,7 +88,7 @@
 
 			<div class="w-full h-full bg-cover bg-center z-10 md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-4" style="background-image: url({{ utc_hero.hero_bg }})">
 			
-				<div class="h-full w-full bg-gray-400 bg-opacity-90"></div>
+				<div class="h-full w-full bg-opacity-90 {{ bg_color }}"></div>
 				</div>
 
 

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
@@ -43,7 +43,7 @@
 
 		 
 		{% if utc_hero.hero_align == 'Left' %}
-		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-8 lg:grid-flow-row lg:mb-4 2xl:grid-cols-utcherolarge text-center">
+		<div class="grid grid-cols-1 md:grid-flow-col lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-8 lg:grid-flow-row grid-flow-col lg:mb-4 2xl:grid-cols-utcherolarge text-center">
 			{% if utc_hero.hero_image %}
 				<div class="2xl:col-start-2 lg:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto col-span-1 z-30">
 				{{ utc_hero.hero_image }} 
@@ -51,7 +51,7 @@
 			{% endif %}
 				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:my-auto lg:mx-8 p-4 z-30">
 		{% else %}
-		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-8 grid-flow-row lg:mb-4 2xl:grid-cols-utcherolargeright text-center">
+		<div class="grid grid-cols-1 md:grid-flow-col lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-8 grid-flow-row lg:mb-4 2xl:grid-cols-utcherolargeright text-center">
 			{% if utc_hero.hero_image %}
 				<div class="lg:col-start-3 lg:col-end-5 2xl:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto z-30">
 				{{ utc_hero.hero_image }}
@@ -77,8 +77,8 @@
 			{% endif %}
 			{% if utc_hero.hero_button_url %}
 				{% if utc_hero.hero_button_text %}
-					<p class="mt-6 lg:mr-16 text-right">
-						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out {{ body_color }} hover:text-utc-new-blue-500 hover:bg-white transform hover:scale-105 py-2 px-4 border border-utc-new-blue-500 lg:border-white" aria-label="Read the release">
+					<p class="mt-6 xl:mr-16 text-right">
+						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out {{ body_color }} hover:text-utc-new-blue-500 hover:bg-white transform hover:scale-105 py-2 px-4 border lg:border-white border-utc-new-blue-500 " aria-label="Read the release">
 							Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i></a>
 					</p>
 					<p>

--- a/source/default/tailwind.config.js
+++ b/source/default/tailwind.config.js
@@ -38,8 +38,8 @@ module.exports = {
         // Adds a custom template for the utc hero block
         'utchero': '1fr 1fr 1fr',
         'utcheroright': '10px 1fr 1fr 1fr',
-        'utcherolarge': '1fr minmax(min-content,120rem) minmax(min-content,40rem) 1fr',
-        'utcherolargeright': '1fr minmax(min-content,40rem) minmax(min-content,120rem) 1fr',
+        'utcherolarge': '1fr minmax(min-content,120rem) minmax(min-content,45rem) 1fr',
+        'utcherolargeright': '1fr minmax(min-content,45rem) minmax(min-content,120rem) 1fr',
       }
     },
   },

--- a/source/default/tailwind.config.js
+++ b/source/default/tailwind.config.js
@@ -37,7 +37,9 @@ module.exports = {
       gridTemplateColumns: {
         // Adds a custom template for the utc hero block
         'utchero': '1fr 1fr 1fr',
+        'utcheroright': '10px 1fr 1fr 1fr',
         'utcherolarge': '1fr minmax(min-content,120rem) minmax(min-content,40rem) 1fr',
+        'utcherolargeright': '1fr minmax(min-content,40rem) minmax(min-content,120rem) 1fr',
       }
     },
   },

--- a/source/default/tailwind.config.js
+++ b/source/default/tailwind.config.js
@@ -38,8 +38,8 @@ module.exports = {
         // Adds a custom template for the utc hero block
         'utchero': '1fr 1fr 1fr',
         'utcheroright': '10px 1fr 1fr 1fr',
-        'utcherolarge': '1fr minmax(min-content,120rem) minmax(min-content,45rem) 1fr',
-        'utcherolargeright': '1fr minmax(min-content,45rem) minmax(min-content,120rem) 1fr',
+        'utcherolarge': '1fr minmax(min-content,120rem) minmax(min-content,50rem) 1fr',
+        'utcherolargeright': '1fr minmax(min-content,50rem) minmax(min-content,120rem) 1fr',
       }
     },
   },


### PR DESCRIPTION
These are the latest additions for the Hero block. Adds a way to select background images, between right/left, and background colors.

![hero-5](https://user-images.githubusercontent.com/50490141/114340610-f9161000-9b25-11eb-863a-010e41e982b4.gif)

![hero-6](https://user-images.githubusercontent.com/50490141/114340618-fca99700-9b25-11eb-9b08-29fe61ef1eb3.gif)

![hero-7](https://user-images.githubusercontent.com/50490141/114340624-00d5b480-9b26-11eb-99a5-65b51176a666.gif)





Questions:

- Do we want to have any background on the smaller screen views?
- Do we still need a "default" and "full" view? Or, can I just keep default for now? Right now, nothing is tied directly to view mode.

@bmartinez287 do you have any time to get together to look at how I have the config setup before I push that to UTC cloud? There are a few things I have questions about (e.g. bg image taxonomy, tags, etc.) that would probably just be quicker to discuss via a video chat.