### PR TITLE
UTC-195-RSS Calendar Edits

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block---id-34701-label-Aggregator-Entity-Browser.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block---id-34701-label-Aggregator-Entity-Browser.html.twig
@@ -1,0 +1,53 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+<p class='font-semibold tracking-widest text-lg mt-0 mb-4' >CALENDARS</p>
+<div class='bg-white shadow-lg'>
+  <div{{ attributes.addClass('aggregator-feed', 'h-80','overflow-auto') }}>
+    {{ title_prefix }}
+    {% if label %}
+      {# <h2{{ title_attributes }}>  conflict with https://github.com/bmartinez287/particle/commit/270309ffbaa1101cbb331b3b98a1b00968601929#}
+      <h2>
+        {{ label }}
+      </h2>
+    {% endif %}
+    {{ title_suffix }}
+    
+    {% block content %}
+      <div{{ content_attributes }}>{{ content }}</div>
+    {% endblock %}
+  </div>
+  <div class="p-2 bg-gray-200 text-right border-t-2 border-gray-300">
+      <a href="https://events.utc.edu/">
+        Master Calendar 
+      </a> 
+      |
+      <a class="pr-2" href="http://gomocs.com/#events-container">
+        Athletics Calendar 
+      </a>
+  </div>
+</div>

--- a/apps/drupal-default/particle_theme/templates/content/aggregator-item.html.twig
+++ b/apps/drupal-default/particle_theme/templates/content/aggregator-item.html.twig
@@ -27,33 +27,31 @@
 {% block item %}
 	{% set date = adapted_time | split('-') %}
 <a href="{{ url }}" class="hover:text-utc-new-blue-500">
-	<article class="relative box-border flex flex-none flex-row min-w-0 border-0 rounded-none mt-3 shadow bg-white">
+	<article class="relative box-border flex flex-auto flex-row min-w-0 rounded-none border-b-2 border-gray-300">
     {# flex-initial missing aligment for long text #}
-		<div class="flex flex-35 text-center flex-col items-center justify-center px-4 border-r-2 my-3 border-utc-new-blue-500">
+		<div class="flex text-center flex-col items-center justify-center px-4 border-l-4 my-3 border-utc-new-blue-500">
+			<p class="text-3xl m-0">{{date[1]}}</p>
 			<p class="font-bold text-lg uppercase tracking-wider m-0">{{date[0]}}</p>
-			<p class="text-4xl m-0">{{date[1]}}</p>
 		</div>
-<div class="p-3 h-auto flex-75 justify-center flex flex-col">
+		<div class="p-3 h-auto justify-center w-75 flex flex-col">
+			{{ title_prefix }}
+			{# {{adapted_time}} #} 
+			{% if title %}
+				{% block title %}
+					<span class="font-semibold">
+						{{ title }}
+					</span>
+				{% endblock %}
+			{% endif %}
 
-		{{ title_prefix }}
-		{# {{adapted_time}} #} 
-		{% if title %}
-			{% block title %}
-				<span class="font-semibold">
-					{{ title }}
-				</span>
-			{% endblock %}
-		{% endif %}
-
-		{{ title_suffix }}
-
-		{% block content %}
+			{{ title_suffix }}
+			{% block content %}
 			{# {{content}} #}
 
 			{# alternative number one #}
 			{# {% set eventtime = content.description['#markup'] | split('-')[0] %} #}
 			{% set foo = content.description['#markup'] | split('-') %}
-		{% set footwo = foo[1] | split(':') %}
+			{% set footwo = foo[1] | split(':') %}
 			{# {{ foo[0]}}
 						{{ footwo[0]}}
 					{{adapted_time}} #}
@@ -61,7 +59,10 @@
 			{# {{ dump(content.timestamp['#items'].0.list) }} #}
 			{#       {{ elements.['#aggregator_item'] }}#}
 			{#       {{ devel_breakpoint() }}#}{#      {{ devel_breakpoint() }}#}
-		{% endblock %}
+			{% endblock %}
+		</div>
+		<div class="p-5 my-2 items-end flex flex-col justify-center">
+			<i class="fas fa-angle-right text-2xl"></i>
 		</div>
 	</article>
 	</a>

--- a/apps/drupal-default/particle_theme/templates/content/aggregator-item.html.twig
+++ b/apps/drupal-default/particle_theme/templates/content/aggregator-item.html.twig
@@ -27,7 +27,7 @@
 {% block item %}
 	{% set date = adapted_time | split('-') %}
 <a href="{{ url }}" class="hover:text-utc-new-blue-500">
-	<article class="relative box-border flex flex-auto flex-row min-w-0 rounded-none border-b-2 border-gray-300">
+	<article class="relative box-border flex flex-auto flex-row min-w-0 rounded-none border-b-2 border-gray-300 hover:bg-gray-100">
     {# flex-initial missing aligment for long text #}
 		<div class="flex text-center flex-col items-center justify-center px-4 border-l-4 my-3 border-utc-new-blue-500">
 			<p class="text-3xl m-0">{{date[1]}}</p>

--- a/apps/drupal-default/particle_theme/templates/content/aggregator-item.html.twig
+++ b/apps/drupal-default/particle_theme/templates/content/aggregator-item.html.twig
@@ -26,22 +26,22 @@
 
 {% block item %}
 	{% set date = adapted_time | split('-') %}
-
-	<article class="lg flex hover:bg-gray-100 bg-white mb-4 py-2 px-4 border border-gray-400">
+<a href="{{ url }}" class="hover:text-utc-new-blue-500">
+	<article class="relative box-border flex flex-none flex-row min-w-0 border-0 rounded-none mt-3 shadow bg-white">
     {# flex-initial missing aligment for long text #}
-		<div class="text-center flex flex-col pr-4">
-			<h4 class="month">{{date[0]}}</h4>
-			<h1 class="day">{{date[1]}}</h1>
+		<div class="flex flex-35 text-center flex-col items-center justify-center px-4 border-r-2 my-3 border-utc-new-blue-500">
+			<p class="font-bold text-lg uppercase tracking-wider m-0">{{date[0]}}</p>
+			<p class="text-4xl m-0">{{date[1]}}</p>
 		</div>
-
+<div class="p-3 h-auto flex-75 justify-center flex flex-col">
 
 		{{ title_prefix }}
-		{# {{adapted_time}} #}
+		{# {{adapted_time}} #} 
 		{% if title %}
 			{% block title %}
-				<h3>
-					<a href="{{ url }}">{{ title }}</a>
-				</h3>
+				<span class="font-semibold">
+					{{ title }}
+				</span>
 			{% endblock %}
 		{% endif %}
 
@@ -62,7 +62,9 @@
 			{#       {{ elements.['#aggregator_item'] }}#}
 			{#       {{ devel_breakpoint() }}#}{#      {{ devel_breakpoint() }}#}
 		{% endblock %}
+		</div>
 	</article>
+	</a>
 {% endblock %}
 
 {% block after %}{% endblock %}

--- a/apps/drupal-default/particle_theme/templates/dataset/aggregator-feed--entity-browser-utc-homepage.html.twig
+++ b/apps/drupal-default/particle_theme/templates/dataset/aggregator-feed--entity-browser-utc-homepage.html.twig
@@ -26,12 +26,13 @@
 
 <div>
 	<details>
-		<summary class="card-header_m" id="cardH-{{random(50)}}">
-			<a href="#homepagefeed">
+		<summary class="card-header_m border-2 border-gray-300" id="cardH-{{random(50)}}">
+		{# do we need to keep this? Removing makes accordion open when text is clicked (expected behavior)
+			<a href="#homepagefeed"> #}
 				{{ title }}
-			</a>
+		{#	</a> #}
 		</summary>
-		<div class="mt-1">
+		<div class="bg-white shadow">
 			{{ content }}
 		</div>
 	</details>

--- a/source/default/tailwind.config.js
+++ b/source/default/tailwind.config.js
@@ -40,7 +40,11 @@ module.exports = {
         'utcheroright': '10px 1fr 1fr 1fr',
         'utcherolarge': '1fr minmax(min-content,120rem) minmax(min-content,50rem) 1fr',
         'utcherolargeright': '1fr minmax(min-content,50rem) minmax(min-content,120rem) 1fr',
-      }
+      },
+      flex: {
+       '35': '0 1 35%',
+       '75': '0 1 75%',
+      },
     },
   },
   variants: {},

--- a/source/default/tailwind.config.js
+++ b/source/default/tailwind.config.js
@@ -40,7 +40,7 @@ module.exports = {
         'utcheroright': '10px 1fr 1fr 1fr',
         'utcherolarge': '1fr minmax(min-content,120rem) minmax(min-content,50rem) 1fr',
         'utcherolargeright': '1fr minmax(min-content,50rem) minmax(min-content,120rem) 1fr',
-      },
+      }
     },
   },
   variants: {},

--- a/source/default/tailwind.config.js
+++ b/source/default/tailwind.config.js
@@ -41,10 +41,6 @@ module.exports = {
         'utcherolarge': '1fr minmax(min-content,120rem) minmax(min-content,50rem) 1fr',
         'utcherolargeright': '1fr minmax(min-content,50rem) minmax(min-content,120rem) 1fr',
       },
-      flex: {
-       '35': '0 1 35%',
-       '75': '0 1 75%',
-      },
     },
   },
   variants: {},


### PR DESCRIPTION
Relates to #195

This modifies the RSS calendar block on the homepage:

**When tab is clicked:**

<img width="457" alt="Screen Shot 2021-05-02 at 10 32 17 PM" src="https://user-images.githubusercontent.com/50490141/116837063-eb88fe80-ab96-11eb-8fc2-1ef9ff10b757.png">

**Hovered event:**

<img width="457" alt="Screen Shot 2021-05-02 at 10 32 35 PM" src="https://user-images.githubusercontent.com/50490141/116837074-f5126680-ab96-11eb-84a0-48782afb30dd.png">

**No tab clicked (default view):**

<img width="457" alt="Screen Shot 2021-05-02 at 10 32 24 PM" src="https://user-images.githubusercontent.com/50490141/116837102-0eb3ae00-ab97-11eb-8758-7ee434ec3c63.png">

I am thinking I'll take a look at the bottom buttons and the accordion style in general a bit more, but had a few questions before I work on that piece.

**Questions:**

- Have we thought about doing tabs (e.g. https://material.io/components/tabs#usage ) instead of an accordion? I'm curious about the pros/cons of the accordions being closed when they arrive on the page.

 - Do we want/not want the arrows on the right of the events? Pro: shows this is a clickable item for more info. Con: takes up some space for event title, making events take up more space.

 - Anything else I should change? Open to all ideas.

