### PR TITLE
Feature/UTC-217-Newsroom Edits

### DIFF
--- a/apps/drupal-default/particle_theme/templates/views/views-view-unformatted--utc-newsroom--utc_newsroom_grid.html.twig
+++ b/apps/drupal-default/particle_theme/templates/views/views-view-unformatted--utc-newsroom--utc_newsroom_grid.html.twig
@@ -21,7 +21,7 @@
 		{{ title }}
 	</h3>
 {% endif %}
-<div class="box-border max-w-4xl mx-auto xl:masonry before:box-inherit after:box-inherit">
+<div class="box-border mx-auto mt-10 md:masonry-2 xl:masonry-3 before:box-inherit after:box-inherit">
 	{% for key,row in rows %}
 		{% set content = {
 			news_link: view.style_plugin.getField(key, 'field_utc_rss_feed_item_link')|striptags|trim,
@@ -32,11 +32,11 @@
 			news_body: view.style_plugin.getField(key, 'field_utc_rss_feed_item_body')|striptags|trim,
 			news_imageurl: view.style_plugin.getField(key, 'field_utc_rss_feed_item_img_url'),
  		} %}
-		<div class="group break-inside p-4 my-6 bg-white shadow rounded-lg xl:min-h-23 hover:bg-utc-new-blue-100 transition duration-700">
+		<div class="group break-inside p-4 my-6 bg-white shadow rounded xl:min-h-23 hover:bg-utc-new-blue-100 transition duration-700 border-b-4 border-utc-new-gold-500">
 			<a
 				href={{content.news_link}}>
 				{# <img class="w-full" src="/mountain.jpg" alt="Mountain"> #}
-				<div class="p-6">
+				<div class="p-4">
 					<p class="font-bold text-xl mb-2">{{ content.news_title }}</p>
 					<p class="text-gray-700 text-base">
 						{{content.news_body}}

--- a/apps/drupal-default/particle_theme/templates/views/views-view-unformatted--utc-newsroom--utc_newsroom_grid.html.twig
+++ b/apps/drupal-default/particle_theme/templates/views/views-view-unformatted--utc-newsroom--utc_newsroom_grid.html.twig
@@ -32,7 +32,7 @@
 			news_body: view.style_plugin.getField(key, 'field_utc_rss_feed_item_body')|striptags|trim,
 			news_imageurl: view.style_plugin.getField(key, 'field_utc_rss_feed_item_img_url'),
  		} %}
-		<div class="group break-inside p-4 my-6 bg-white shadow rounded xl:min-h-23 hover:bg-utc-new-blue-100 transition duration-700 border-b-4 border-utc-new-gold-500">
+		<div class="group break-inside p-4 my-6 bg-white shadow xl:min-h-23 hover:bg-utc-new-blue-100 transition duration-700 border-b-4 border-utc-new-gold-500">
 			<a
 				href={{content.news_link}}>
 				{# <img class="w-full" src="/mountain.jpg" alt="Mountain"> #}

--- a/apps/drupal-default/particle_theme/templates/views/views-view-unformatted--utc-newsroom--utc_newsroom_grid.html.twig
+++ b/apps/drupal-default/particle_theme/templates/views/views-view-unformatted--utc-newsroom--utc_newsroom_grid.html.twig
@@ -21,7 +21,7 @@
 		{{ title }}
 	</h3>
 {% endif %}
-<div class="box-border mx-auto mt-10 md:masonry-2 xl:masonry-3 before:box-inherit after:box-inherit">
+<div class="box-border mx-auto mt-16 md:masonry-2 xl:masonry-3 before:box-inherit after:box-inherit">
 	{% for key,row in rows %}
 		{% set content = {
 			news_link: view.style_plugin.getField(key, 'field_utc_rss_feed_item_link')|striptags|trim,

--- a/apps/drupal-default/particle_theme/templates/views/views-view-unformatted--utc-newsroom--utc_newsroom_highlights.html.twig
+++ b/apps/drupal-default/particle_theme/templates/views/views-view-unformatted--utc-newsroom--utc_newsroom_highlights.html.twig
@@ -32,13 +32,13 @@
     news_body: view.style_plugin.getField(key, 'field_utc_rss_feed_item_body'),
     news_imageurl: view.style_plugin.getField(key, 'field_utc_rss_feed_item_img_url'),
  } %}
-		<div class="ml-8 my-4 bg-white hover:bg-gray-200">
+		<div class="sm:ml-8 my-4 bg-white shadow hover:bg-gray-200 border-b-4 border-utc-new-gold-500">
 			<a href={{content.news_link}}>
-				<div class="max-w-xs rounded overflow-hidden shadow-lg">
+				<div class="max-w-xs overflow-hidden">
 					{{ content.news_image }}
 					{# <img class="w-full" src="/mountain.jpg" alt="Mountain"> #}
 					<div class="px-6 py-4">
-						<div class="font-bold text-xl text-center mb-2">{{ content.news_title }}</div>
+						<div class="font-semibold text-xl text-center mb-2">{{ content.news_title }}</div>
 						{# <p class="text-gray-700 text-base">
 						          Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatibus quia, nulla! Maiores et perferendis eaque, exercitationem praesentium nihil.
 						        </p> #}

--- a/apps/drupal-default/particle_theme/templates/views/views-view-unformatted--utc-newsroom--utc_newsroom_titles.html.twig
+++ b/apps/drupal-default/particle_theme/templates/views/views-view-unformatted--utc-newsroom--utc_newsroom_titles.html.twig
@@ -21,7 +21,7 @@
 		{{ title }}
 	</h3>
 {% endif %}
-<div class="md:grid md:grid-flow-col md:grid-cols-3 md:grid-rows-3 md:gap-4">
+<div class="md:grid md:grid-flow-col md:grid-cols-3 md:grid-rows-3 md:gap-8 ml-2">
 	{% for key,row in rows %}
 		{% set content = {
 	news_link: view.style_plugin.getField(key, 'field_utc_rss_feed_item_link')|striptags|trim,
@@ -37,9 +37,11 @@
 			<a
 				href={{content.news_link}}>
 				{# <img class="w-full" src="/mountain.jpg" alt="Mountain"> #}
-				<div class="px-6 py-4 hover:bg-gray-200">
-				    <div class="font-bold text-lg mb-2"> {{content.news_location}} </div>
-					<div class="text-xl mb-2">{{ content.news_title }}</div>
+				<div class="pr-4 my-2 hover:bg-gray-200">
+				<div class="border-l-4 border-utc-new-gold-500 py-1"> 
+				    <div class="text-base mb-1 uppercase font-bold tracking-wide pl-3"> {{content.news_location}} </div>
+					<div class="text-xl mb-1 pl-3">{{ content.news_title }}</div>
+					</div>
 					{# <p> {{content.news_pubdate}} </p> #}
 				</div>
 			</a>

--- a/apps/drupal-default/particle_theme/templates/views/views-view-unformatted--utc-newsroom--utc_newsroom_titles.html.twig
+++ b/apps/drupal-default/particle_theme/templates/views/views-view-unformatted--utc-newsroom--utc_newsroom_titles.html.twig
@@ -37,9 +37,9 @@
 			<a
 				href={{content.news_link}}>
 				{# <img class="w-full" src="/mountain.jpg" alt="Mountain"> #}
-				<div class="pr-4 my-2 hover:bg-gray-200">
+				<div class="pr-4 my-4 hover:bg-gray-200">
 				<div class="border-l-4 border-utc-new-gold-500 py-1"> 
-				    <div class="text-base mb-1 uppercase font-bold tracking-wide pl-3"> {{content.news_location}} </div>
+				    <div class="text-base my-1 uppercase font-bold tracking-wide pl-3"> {{content.news_location}} </div>
 					<div class="text-xl mb-1 pl-3">{{ content.news_title }}</div>
 					</div>
 					{# <p> {{content.news_pubdate}} </p> #}

--- a/source/default/_patterns/00-protons/tailwind.tokens.css
+++ b/source/default/_patterns/00-protons/tailwind.tokens.css
@@ -18,9 +18,13 @@ Monospace - Google Fonts - Source Code Pro
 
 @layer utilities {
   @variants responsive {
-    .masonry {
+    .masonry-2 {
       column-count: 2;
       column-gap: 1.5em;
+    }
+    .masonry-3 {
+      column-count: 3;
+      column-gap: 2em;
     }
     .break-inside {
       break-inside: avoid;


### PR DESCRIPTION
A few more style edits on the Newsroom, including on featured news.

![newsroom](https://user-images.githubusercontent.com/50490141/118427820-16497b80-b69c-11eb-984d-912d446addd5.gif)

Do we want the "Featured News" to be cards? I added a yellow accent line but didn't go full card style...although we can. The grid items are in three columns now and will look more balanced if a few more (six, maybe?) can be enabled to show via the feed.