### PR TITLE
Feature/UTC-252 card image cropping

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--utc-card-base.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-card-base.html.twig
@@ -23,7 +23,7 @@
  *   displayed after the main title tag that appears in the template.
  *
  * @see template_preprocess_block()
- *
+ * 
  * Base used by block--utc-card.html.twig
  */
 #}
@@ -38,6 +38,7 @@
   card_width ? 'utc-card-2--w-' ~ card_width,
   text_alignment ? 'utc-card-2--align-' ~ text_alignment,
   card_link ? 'utc-card-2--card-link',
+  card_img_fill ? card_img_fill
 ] | sort | join(' ') | trim %}
 
 {# could use include statements for items like images and buttons in design system #}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-card.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-card.html.twig
@@ -23,6 +23,7 @@
 	{% set card_count = content["#block_content"].field_card_count.0.value %}
 	{% set card_width = content.field_single_card_width|field_value|render %}
 	{% set card_type = content["#block_content"].field_card_type.0.value %}
+	{% set card_img_fill = content.field_card_image_fill[0]|render == 'On' ? 'utc-card-2--img-no-fill' %}
 
 	{# set variables for card content based on Drupal input #}
 	{% set item_card_1 = {

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-card.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-card.html.twig
@@ -23,7 +23,9 @@
 	{% set card_count = content["#block_content"].field_card_count.0.value %}
 	{% set card_width = content.field_single_card_width|field_value|render %}
 	{% set card_type = content["#block_content"].field_card_type.0.value %}
-	{% set card_img_fill = content.field_card_image_fill[0]|render == 'On' ? 'utc-card-2--img-no-fill' %}
+	{% if card_type == 'wide' %}
+		{% set card_img_fill = content.field_card_image_fill[0]|render == 'On' ? 'utc-card-2--img-no-fill' %}
+	{% endif %}
 
 	{# set variables for card content based on Drupal input #}
 	{% set item_card_1 = {

--- a/source/default/_patterns/00-protons/legacy/css/components/card/_card.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/card/_card.css
@@ -29,9 +29,14 @@ in particle */
 /* make image span full width and height and crop to fit regardless of container sizing */
 
 .utc-card-2 img {
-    height: auto;
+    height: 100%;
     width: 100%;
     object-fit: cover;
+}
+
+.utc-card-2--img-no-fill img {
+    height: auto;
+    padding: 15px
 }
 
 .utc-card-2__body {

--- a/source/default/_patterns/00-protons/legacy/css/components/card/_card.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/card/_card.css
@@ -62,6 +62,7 @@ in particle */
     position: absolute;
     bottom: 0;
     margin-bottom: 0.25rem;
+    margin-left: .5rem;
 }
 
 .utc-card-2--align-center {


### PR DESCRIPTION
This fixes issues #252.

To fix the problem with cropping on wide cards, adds a check box to elect to "not crop" image, enforcing auto height and adding a bit of padding:

![card-fix](https://user-images.githubusercontent.com/50490141/120950200-4670c100-c714-11eb-9253-85608fddc591.gif)

<img width="1464" alt="Screen Shot 2021-06-06 at 10 07 14 PM" src="https://user-images.githubusercontent.com/50490141/120950212-512b5600-c714-11eb-9553-f630bcf77264.png">

If this looks okay, I can add needed config in UTC cloud once it is merged.
