### PR TITLE
UTC-190-Fix Layout Builder Contrast

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/layout-builder.css
+++ b/source/default/_patterns/00-protons/legacy/css/layout-builder.css
@@ -1,8 +1,32 @@
 
-/* //local overrides */
+/* 
+//overriding style from themag to improve contrast on layout builder off-canvas
+// I think if/when we took themag theme out this */
 
 #drupal-off-canvas .inline-block-create-button, #drupal-off-canvas .inline-block-list__item {
   background-color: #1c2429;
+}
+
+#drupal-off-canvas ul.layout-selection {
+  background-color: #444;
+}
+
+#drupal-off-canvas .layout-builder-configure-section .description,
+#drupal-off-canvas .layout-builder-configure-section .form-item .description,
+#drupal-off-canvas .layout-builder-configure-section .details-description,
+#drupal-off-canvas .layout-builder-configure-section *, 
+#drupal-off-canvas .layout-builder-configure-section *:not(div),
+#drupal-off-canvas .layout-selection .description,
+#drupal-off-canvas .layout-selection .form-item .description,
+#drupal-off-canvas .layout-selection .details-description,
+#drupal-off-canvas .layout-selection *, 
+#drupal-off-canvas .layout-selection *:not(div)
+ {
+  color: white !important;
+}
+
+#drupal-off-canvas .layout-builder-configure-section label {
+  font-size: .85rem;
 }
 
 /* //override white background on layout builder blocks in UI */


### PR DESCRIPTION
This improves the contrast, increases font size for labels, and removes bg color from the first part of the menu.

These edits are a hacky override of what's coming in from themag, I think if we end up removing/disabling that theme eventually these edits will no longer be needed.

<img width="223" alt="Screen Shot 2021-06-19 at 2 51 45 PM" src="https://user-images.githubusercontent.com/50490141/122652667-eadc0580-d10d-11eb-8863-bb722f92a6eb.png">

<img width="223" alt="Screen Shot 2021-06-19 at 2 51 33 PM" src="https://user-images.githubusercontent.com/50490141/122652671-ed3e5f80-d10d-11eb-87d7-edb8848c0800.png">
