### PR TITLE
Feature/utc 245 utc hero to additional content types

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
@@ -13,95 +13,96 @@
 #}
 
 {% block content %}
-	{% set rendered_content = content|render %}
-	{# Sets variable to trigger content render array. #}
-	{# hero_button_link: content.field_hero_button|field_value, #}
-	{% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %}
-	{% set utc_hero = {
-	hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_image_select)["#object"].field_image_url.value,
-	hero_align: content["#block_content"].field_hero_align.0.value,
-	hero_color: content["#block_content"].field_hero_color.0.value,
-	hero_tag: content.field_hero_tag|field_value,
+    {% set rendered_content = content|render %}
+    {# Sets variable to trigger content render array. #}
+    {# hero_button_link: content.field_hero_button|field_value, #}
+    {% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %}
+    {% set utc_hero = {
+    hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_image_select)["#object"].field_image_url.value,
+    hero_align: content["#block_content"].field_hero_align.0.value,
+    hero_color: content["#block_content"].field_hero_color.0.value,
+    hero_tag: content.field_hero_tag|field_value,
     hero_title: content.field_hero_title|field_value,
     hero_image: content.field_utc_media|field_value,
     hero_text: content.field_hero_text|field_value,
     hero_button_text: content.field_hero_button.0['#title'],
     hero_button_url: content.field_hero_button.0['#url'],
     } %}
-	{# Sets colors for hero content depending on selection #}
-	{% if utc_hero.hero_color == 'Dark Blue' %}
-	{% set title_color = 'lg:text-white' %}
-	{% set body_color = 'lg:text-white' %}
-	{% set bg_color = 'bg-utc-new-blue-500' %}
-	{% else %}
-	{% set title_color = 'text-utc-new-blue-500' %}
-	{% set body_color = 'text-base' %}
-	{% set bg_color = 'bg-utc-new-blue-300' %}
-	{% endif %}
+    {# Sets colors for hero content depending on selection #}
+    {# Remove background color and alter opacities #}
+    {% if utc_hero.hero_color == 'Dark Blue' %}
+    {% set title_color = 'lg:text-white' %}
+    {% set body_color = 'lg:text-white' %}
+    {% set bg1_opacity = '' %}
+    {% set bg2_opacity = 'bg-opacity-90' %}
+    {% else %}
+    {% set title_color = 'text-utc-new-blue-500' %}
+    {% set body_color = 'text-base' %}
+    {% set bg1_opacity = 'bg-opacity-15' %}
+    {% set bg2_opacity = 'bg-opacity-20' %}
+    {% endif %}
+
+     
+        {% if utc_hero.hero_align == 'Left' %}
+        <div class="utc-hero-wrapper-left lg:grid lg:grid-rows-utchero lg:grid-cols-utchero lg:grid-flow-row lg:mb-4 2xl:grid-cols-utcherolarge text-center">
+            {% if utc_hero.hero_image %}
+                <div class="2xl:col-start-2 lg:col-start-1 md:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto lg:mt-8 col-span-1 z-30">
+                {{ utc_hero.hero_image }} 
+                </div>
+            {% endif %}
+
+                <div class="lg:col-start-3 md:col-start-1 lg:col-end-4 lg:row-start-2 lg:row-end-3 lg:mx-8 p-4 pb-0 lg:pb-4 z-30 self-end">
+        {% else %}
+        <div class="utc-hero-wrapper-right lg:grid lg:grid-rows-utchero lg:grid-cols-utcheroright lg:grid-flow-row lg:mb-4  2xl:grid-cols-utcherolargeright text-center">
+            {% if utc_hero.hero_image %}
+                <div class="lg:col-start-4 xl:col-start-3 lg:col-end-5 2xl:col-end-4 lg:row-start-1 xl:row-start-2 lg:row-end-5 lg:mt-8 xl:m-auto z-30">
+                {{ utc_hero.hero_image }}
+                </div>
+            {% endif %}
+        
+                <div class="2xl:col-start-2 lg:col-start-2 md:col-start-1 lg:col-end-4 xl:col-end-2 lg:row-start-2 lg:row-end-3 lg:mx-8 pt-4 px-6 pb-0 lg:pb-4 col-span-1 z-30 self-end">
+        {% endif %}
+            {% if utc_hero.hero_tag %}
+                <p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">
+                    {{ utc_hero.hero_tag }}
+                </p>
+                <hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20" />
+            {% endif %}
+            {% if utc_hero.hero_title %}
+                <h2 class="text-left {{ title_color }}">
+                    {{ utc_hero.hero_title }}
+                </h2>
+            {% endif %}
+            </div>
+            {% if utc_hero.hero_align == 'Left' %}
+            <div class="lg:col-start-3 md:col-start-1 lg:col-end-4 lg:row-start-3 lg:row-end-4 lg:mx-8 p-4 z-30 pt-0 lg:pt-4">
+            {% else %}
+            <div class="2xl:col-start-2 lg:col-start-2 md:col-start-1 lg:col-end-2 lg:row-start-3 lg:row-end-4 lg:mx-8 p-4 col-span-1 z-30 pt-0 lg:pt-4">
+            {% endif %}
+            {% if utc_hero.hero_text %}
+                <p class="text-left text-lg text-base">
+                    {{ utc_hero.hero_text}}
+                </p>
+            {% endif %}
+            {% if utc_hero.hero_button_url %}
+                {% if utc_hero.hero_button_text %}
+                    <p class="mt-6 xl:mr-16 text-right">
+                        <a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out text-base hover:bg-gray-200 lg:hover:text-utc-new-blue-500 lg:hover:bg-white transform hover:scale-105 py-2 px-4 border border-utc-new-blue-500" aria-label="Read the release">
+                            Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i></a>
+                    </p>
+                    {% endif %}
+                {% endif %}
+
+                </div>
+
+            <div class="w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-3" style="background-image: url({{ utc_hero.hero_bg }})">
+            
+                <div class="h-full w-full {{ bg2_opacity }} bg-utc-new-blue-500"></div>
+                </div>
+        
 
 
-
-		 
-		{% if utc_hero.hero_align == 'Left' %}
-		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utchero lg:grid-flow-row lg:mb-4 2xl:grid-cols-utcherolarge text-center">
-			{% if utc_hero.hero_image %}
-				<div class="2xl:col-start-2 lg:col-start-1 md:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto lg:mt-8 col-span-1 z-30">
-				{{ utc_hero.hero_image }} 
-				</div>
-			{% endif %}
-
-				<div class="lg:col-start-3 md:col-start-1 lg:col-end-4 lg:row-start-2 lg:row-end-3 lg:mx-8 p-4 pb-0 lg:pb-4 z-30 self-end">
-		{% else %}
-		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utcheroright lg:grid-flow-row lg:mb-4  2xl:grid-cols-utcherolargeright text-center">
-			{% if utc_hero.hero_image %}
-				<div class="lg:col-start-3 lg:col-end-5 md:col-start-1 2xl:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto lg:mt-8 z-30">
-				{{ utc_hero.hero_image }}
-				</div>
-			{% endif %}
-		
-				<div class="2xl:col-start-2 lg:col-start-2 md:col-start-1 lg:col-end-2 lg:row-start-2 lg:row-end-3 lg:mx-8 pt-4 px-6 pb-0 lg:pb-4 col-span-1 z-30 self-end">
-		{% endif %}
-			{% if utc_hero.hero_tag %}
-				<p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">
-					{{ utc_hero.hero_tag }}
-				</p>
-				<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20" />
-			{% endif %}
-			{% if utc_hero.hero_title %}
-				<h2 class="text-left {{ title_color }}">
-					{{ utc_hero.hero_title }}
-				</h2>
-			{% endif %}
-			</div>
-			{% if utc_hero.hero_align == 'Left' %}
-			<div class="lg:col-start-3 md:col-start-1 lg:col-end-4 lg:row-start-3 lg:row-end-4 lg:mx-8 p-4 z-30 pt-0 lg:pt-4">
-			{% else %}
-			<div class="2xl:col-start-2 lg:col-start-2 md:col-start-1 lg:col-end-2 lg:row-start-3 lg:row-end-4 lg:mx-8 p-4 col-span-1 z-30 pt-0 lg:pt-4">
-			{% endif %}
-			{% if utc_hero.hero_text %}
-				<p class="text-left text-lg text-base">
-					{{ utc_hero.hero_text}}
-				</p>
-			{% endif %}
-			{% if utc_hero.hero_button_url %}
-				{% if utc_hero.hero_button_text %}
-					<p class="mt-6 xl:mr-16 text-right">
-						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out text-base hover:bg-gray-200 lg:hover:text-utc-new-blue-500 lg:hover:bg-white transform hover:scale-105 py-2 px-4 border border-utc-new-blue-500" aria-label="Read the release">
-							Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i></a>
-					</p>
-					{% endif %}
-				{% endif %}
-
-				</div>
-
-			<div class="w-full h-full bg-cover bg-center z-10 md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-3" style="background-image: url({{ utc_hero.hero_bg }})">
-			
-				<div class="h-full w-full bg-opacity-90 {{ bg_color }}"></div>
-				</div>
-		
+        </div>
 
 
-		</div>
-
-
-	{% endblock %}
+    {% endblock %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
@@ -13,86 +13,86 @@
 #}
 
 {% block content %}
-	{% set rendered_content = content|render %}
-	{# Sets variable to trigger content render array. #}
-	{# hero_button_link: content.field_hero_button|field_value, #}
-	{% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %}
-	{% set utc_hero = {
-	hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_image_select)["#object"].field_image_url.value,
-	hero_align: content["#block_content"].field_hero_align.0.value,
-	hero_color: content["#block_content"].field_hero_color.0.value,
-	hero_tag: content.field_hero_tag|field_value,
+    {% set rendered_content = content|render %}
+    {# Sets variable to trigger content render array. #}
+    {# hero_button_link: content.field_hero_button|field_value, #}
+    {% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %}
+    {% set utc_hero = {
+    hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_image_select)["#object"].field_image_url.value,
+    hero_align: content["#block_content"].field_hero_align.0.value,
+    hero_color: content["#block_content"].field_hero_color.0.value,
+    hero_tag: content.field_hero_tag|field_value,
     hero_title: content.field_hero_title|field_value,
     hero_image: content.field_utc_media|field_value,
     hero_text: content.field_hero_text|field_value,
     hero_button_text: content.field_hero_button.0['#title'],
     hero_button_url: content.field_hero_button.0['#url'],
     } %}
-	{# Sets colors for hero content depending on selection #}
-	{% if utc_hero.hero_color == 'Dark Blue' %}
-	{% set title_color = 'lg:text-white' %}
-	{% set body_color = 'lg:text-white' %}
-	{% set bg_color = 'bg-utc-new-blue-500' %}
-	{% else %}
-	{% set title_color = 'text-utc-new-blue-500' %}
-	{% set body_color = 'text-base' %}
-	{% set bg_color = 'bg-utc-new-blue-300' %}
-	{% endif %}
+    {# Sets colors for hero content depending on selection #}
+    {# Remove background color and alter opacities #}
+    {% if utc_hero.hero_color == 'Dark Blue' %}
+    {% set title_color = 'lg:text-white' %}
+    {% set body_color = 'lg:text-white' %}
+    {% set bg1_opacity = '' %}
+    {% set bg2_opacity = 'bg-opacity-90' %}
+    {% else %}
+    {% set title_color = 'text-utc-new-blue-500' %}
+    {% set body_color = 'text-base' %}
+    {% set bg1_opacity = 'bg-opacity-15' %}
+    {% set bg2_opacity = 'bg-opacity-20' %}
+    {% endif %}
+
+        {% if utc_hero.hero_align == 'Left' %}
+        <div class="utc-hero-wrapper-left lg:grid lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-8 lg:grid-flow-row lg:mb-4 2xl:grid-cols-utcherolarge text-center ">
+            {% if utc_hero.hero_image %}
+                <div class="2xl:col-start-2 lg:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto col-span-1 z-30">
+                {{ utc_hero.hero_image }} 
+                </div>
+            {% endif %}
+                <div class="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:my-auto lg:mx-8 p-4 z-30">
+        {% else %}
+        <div class="utc-hero-wrapper-right lg:grid lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-8 grid-flow-row lg:mb-4 2xl:grid-cols-utcherolargeright text-center">
+            {% if utc_hero.hero_image %}
+                <div class="lg:col-start-4 xl:col-start-3 lg:col-end-5 2xl:col-end-4 lg:row-start-1 xl:row-start-2 lg:row-end-5 lg:mt-8 xl:m-auto z-30">
+                {{ utc_hero.hero_image }}
+                </div>
+            {% endif %}
+                <div class="2xl:col-start-2 lg:col-start-2 lg:col-end-4 xl:col-end-2 lg:row-start-1 lg:row-end-4 lg:my-auto lg:mx-8 py-4 px-6 col-span-1 z-30">
+        {% endif %}
+            {% if utc_hero.hero_tag %}
+                <p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">
+                    {{ utc_hero.hero_tag }}
+                </p>
+                <hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20" />
+            {% endif %}
+            {% if utc_hero.hero_title %}
+                <h2 class="text-left {{ title_color }}">
+                    {{ utc_hero.hero_title }}
+                </h2>
+            {% endif %}
+            {% if utc_hero.hero_text %}
+                <p class="text-left text-lg text-base {{ body_color }}">
+                    {{ utc_hero.hero_text}}
+                </p>
+            {% endif %}
+            {% if utc_hero.hero_button_url %}
+                {% if utc_hero.hero_button_text %}
+                    <p class="mt-6 xl:mr-16 text-right">
+                        <a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out {{ body_color }} hover:bg-gray-200 lg:hover:text-utc-new-blue-500 lg:hover:bg-white transform hover:scale-105 py-2 px-4 border lg:border-white border-utc-new-blue-500 " aria-label="Read the release">
+                            Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i></a>
+                    </p>
+                    <p>
+                    {% endif %}
+                {% endif %}
+                </div>
+
+            <div class="w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-4" style="background-image: url({{ utc_hero.hero_bg }})">
+            
+                <div class="h-full w-full {{ bg2_opacity }} bg-utc-new-blue-500"></div>
+                </div>
 
 
-
-		 
-		{% if utc_hero.hero_align == 'Left' %}
-		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-8 lg:grid-flow-row lg:mb-4 2xl:grid-cols-utcherolarge text-center">
-			{% if utc_hero.hero_image %}
-				<div class="2xl:col-start-2 lg:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto col-span-1 z-30">
-				{{ utc_hero.hero_image }} 
-				</div>
-			{% endif %}
-				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:my-auto lg:mx-8 p-4 z-30">
-		{% else %}
-		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-8 grid-flow-row lg:mb-4 2xl:grid-cols-utcherolargeright text-center">
-			{% if utc_hero.hero_image %}
-				<div class="lg:col-start-3 lg:col-end-5 2xl:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto z-30">
-				{{ utc_hero.hero_image }}
-				</div>
-			{% endif %}
-				<div class="2xl:col-start-2 lg:col-start-2 lg:col-end-2 lg:row-start-1 lg:row-end-4 lg:my-auto lg:mx-8 py-4 px-6 col-span-1 z-30">
-		{% endif %}
-			{% if utc_hero.hero_tag %}
-				<p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">
-					{{ utc_hero.hero_tag }}
-				</p>
-				<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20" />
-			{% endif %}
-			{% if utc_hero.hero_title %}
-				<h2 class="text-left {{ title_color }}">
-					{{ utc_hero.hero_title }}
-				</h2>
-			{% endif %}
-			{% if utc_hero.hero_text %}
-				<p class="text-left text-lg text-base {{ body_color }}">
-					{{ utc_hero.hero_text}}
-				</p>
-			{% endif %}
-			{% if utc_hero.hero_button_url %}
-				{% if utc_hero.hero_button_text %}
-					<p class="mt-6 xl:mr-16 text-right">
-						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out {{ body_color }} hover:bg-gray-200 lg:hover:text-utc-new-blue-500 lg:hover:bg-white transform hover:scale-105 py-2 px-4 border lg:border-white border-utc-new-blue-500 " aria-label="Read the release">
-							Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i></a>
-					</p>
-					<p>
-					{% endif %}
-				{% endif %}
-				</div>
-
-			<div class="w-full h-full bg-cover bg-center z-10 md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-4" style="background-image: url({{ utc_hero.hero_bg }})">
-			
-				<div class="h-full w-full bg-opacity-90 {{ bg_color }}"></div>
-				</div>
+        </div>
 
 
-		</div>
-
-
-	{% endblock %}
+    {% endblock %}

--- a/source/default/_patterns/00-protons/legacy/css/pages/utc_homepages_options.css
+++ b/source/default/_patterns/00-protons/legacy/css/pages/utc_homepages_options.css
@@ -90,3 +90,23 @@ p.small-head-hr {
         width: 100%;
     }
 }
+
+
+/**augment tailwinds bg-opacity-20**/
+
+.bg-opacity-20 {
+    opacity: .2!important
+}
+
+.bg-opacity-15 {
+    opacity: .15!important
+}
+
+@media screen and (min-width:1024px) {
+    .themag-layout--onecol-section .container .utc-hero-wrapper-right .field--name-field-image {
+        margin-left: -2rem;
+    }
+    .themag-layout--onecol-section .container .utc-hero-wrapper-right .field--name-field-image img {
+        max-width: 95%;
+    }
+}


### PR DESCRIPTION
These are before and afters of Hero changes. The right side margin only applies to screens 1024 and up that are in a boxed container.

BEFORE:

![Beforeshot--lt-bg](https://user-images.githubusercontent.com/82905787/124155627-b13bc080-da64-11eb-829d-4830e07cb217.png)

2XL screen
![Beforeshot--right-margin-2XL](https://user-images.githubusercontent.com/82905787/124155635-b4cf4780-da64-11eb-97d0-50189a7b019d.png)

XL screen
![Beforeshot--right-margin-XL](https://user-images.githubusercontent.com/82905787/124155643-b6007480-da64-11eb-86d2-29685adc3b6a.png)

LG screen
![Beforeshot--right-margin-LG](https://user-images.githubusercontent.com/82905787/124155638-b567de00-da64-11eb-85ca-26e504fd9d77.png)



AFTER: 

Light Background Note: If you want more of a bluer hue, this can be done with a custom blue background color, but not with utc-pattern-lab colors. I suggest #104dd4 for the .bg-cover div.bg-opacity-20 to accomplish that.

![Aftershot--lt-bg](https://user-images.githubusercontent.com/82905787/124155682-c0227300-da64-11eb-9e8d-6d60999c1e41.png)

This image background color code is NOT in this Pull Request but gives you an idea of a bluer background using #104dd4 as stated above.

![Screen Shot 2021-07-01 at 12 47 52 PM](https://user-images.githubusercontent.com/82905787/124160909-c1ef3500-da6a-11eb-9686-8178fd0b03c9.png)


2XL screen
![Aftershot--right-margins-2XL](https://user-images.githubusercontent.com/82905787/124155707-c7498100-da64-11eb-9d43-d7b5ecc9fb48.png)

XL screen
![Aftershot--right-margins-XL](https://user-images.githubusercontent.com/82905787/124155716-c9abdb00-da64-11eb-98ec-91b911a6149c.png)

LG screen
![Aftershot--right-margins-LG](https://user-images.githubusercontent.com/82905787/124155711-c9134480-da64-11eb-85f6-fcfe440cf642.png)



