### PR TITLE
Feature/UTC-245-UTC-hero-edits

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
@@ -38,28 +38,26 @@
 	{% set body_color = 'text-base' %}
 	{% set bg_color = 'bg-utc-new-blue-300' %}
 	{% endif %}
-
-
-
 		 
 		{% if utc_hero.hero_align == 'Left' %}
-		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utchero lg:grid-flow-row lg:mb-4 2xl:grid-cols-utcherolarge text-center">
+
+		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utchero lg:grid-flow-row lg:mb-4 text-center">
 			{% if utc_hero.hero_image %}
-				<div class="2xl:col-start-2 lg:col-start-1 md:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto lg:mt-8 col-span-1 z-30">
+				<div class="lg:col-start-2 md:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto lg:mt-8 col-span-1 z-30">
 				{{ utc_hero.hero_image }} 
 				</div>
 			{% endif %}
 
-				<div class="lg:col-start-3 md:col-start-1 lg:col-end-4 lg:row-start-2 lg:row-end-3 lg:mx-8 p-4 pb-0 lg:pb-4 z-30 self-end">
+				<div class="lg:col-start-3 md:col-start-1 lg:col-end-4 lg:row-start-2 lg:row-end-3 lg:ml-8 p-4 pb-0 lg:pb-4 z-30 self-end">
 		{% else %}
-		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utcheroright lg:grid-flow-row lg:mb-4  2xl:grid-cols-utcherolargeright text-center">
+		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utcheroright lg:grid-flow-row lg:mb-4 text-center">
 			{% if utc_hero.hero_image %}
-				<div class="lg:col-start-3 lg:col-end-5 md:col-start-1 2xl:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto lg:mt-8 z-30">
+				<div class="lg:col-start-3 lg:col-end-4 md:col-start-1 lg:row-start-2 lg:row-end-5 lg:m-auto lg:mt-8 z-30">
 				{{ utc_hero.hero_image }}
 				</div>
 			{% endif %}
 		
-				<div class="2xl:col-start-2 lg:col-start-2 md:col-start-1 lg:col-end-2 lg:row-start-2 lg:row-end-3 lg:mx-8 pt-4 px-6 pb-0 lg:pb-4 col-span-1 z-30 self-end">
+				<div class="lg:col-start-2 md:col-start-1 lg:col-end-2 lg:row-start-2 lg:row-end-3 lg:mr-8 pt-4 px-6 pb-0 lg:pb-4 col-span-1 z-30 self-end">
 		{% endif %}
 			{% if utc_hero.hero_tag %}
 				<p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">
@@ -74,18 +72,18 @@
 			{% endif %}
 			</div>
 			{% if utc_hero.hero_align == 'Left' %}
-			<div class="lg:col-start-3 md:col-start-1 lg:col-end-4 lg:row-start-3 lg:row-end-4 lg:mx-8 p-4 z-30 pt-0 lg:pt-4">
+			<div class="lg:col-start-3 md:col-start-1 lg:col-end-4 lg:row-start-3 lg:row-end-4 lg:ml-8 p-6 z-30 pt-0 lg:pt-4">
 			{% else %}
-			<div class="2xl:col-start-2 lg:col-start-2 md:col-start-1 lg:col-end-2 lg:row-start-3 lg:row-end-4 lg:mx-8 p-4 col-span-1 z-30 pt-0 lg:pt-4">
+			<div class="lg:col-start-2 md:col-start-1 lg:col-end-2 lg:row-start-3 lg:row-end-4 lg:mr-8 p-6 col-span-1 z-30 pt-0 lg:pt-4">
 			{% endif %}
 			{% if utc_hero.hero_text %}
 				<p class="text-left text-lg text-base">
-					{{ utc_hero.hero_text}}
+					{{ utc_hero.hero_text }}
 				</p>
 			{% endif %}
 			{% if utc_hero.hero_button_url %}
 				{% if utc_hero.hero_button_text %}
-					<p class="mt-6 xl:mr-16 text-right">
+					<p class="mt-6 text-right">
 						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out text-base hover:bg-gray-200 lg:hover:text-utc-new-blue-500 lg:hover:bg-white transform hover:scale-105 py-2 px-4 border border-utc-new-blue-500" aria-label="Read the release">
 							Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i></a>
 					</p>

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
@@ -28,78 +28,76 @@
     hero_button_text: content.field_hero_button.0['#title'],
     hero_button_url: content.field_hero_button.0['#url'],
     } %}
+
 	{# Sets colors for hero content depending on selection #}
 	{% if utc_hero.hero_color == 'Dark Blue' %}
-	{% set title_color = 'lg:text-white' %}
-	{% set body_color = 'lg:text-white' %}
-	{% set bg_color = 'bg-utc-new-blue-500' %}
+		{% set title_color = 'lg:text-white' %}
+		{% set body_color = 'lg:text-white' %}
+		{% set btn_border_color = "lg:border-white" %}
+		{% set bg_color = 'background-color:#112e51' %}
+		{% set bg1_opacity = '' %}
+    	{% set bg2_opacity = 'opacity-90' %}
 	{% else %}
-	{% set title_color = 'text-utc-new-blue-500' %}
-	{% set body_color = 'text-base' %}
-	{% set bg_color = 'bg-utc-new-blue-300' %}
+		{% set title_color = 'text-utc-new-blue-500' %}
+		{% set body_color = 'text-base' %}
+		{% set btn_border_color = "lg:border-utc-new-blue-500" %}
+		{% set bg_color = 'background-color:#104dd4' %}
+		{% set bg1_opacity = 'opacity-20' %}
+    	{% set bg2_opacity = 'opacity-20' %}
 	{% endif %}
 		 
-		{% if utc_hero.hero_align == 'Left' %}
-
-		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utchero lg:grid-flow-row lg:mb-4 text-center">
+	{% if utc_hero.hero_align == 'Left' %}
+		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-4 lg:grid-flow-row lg:mb-4 text-center">
 			{% if utc_hero.hero_image %}
-				<div class="lg:col-start-2 md:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto lg:mt-8 col-span-1 z-30">
-				{{ utc_hero.hero_image }} 
+				<div class="lg:col-start-2 lg:col-end-3 lg:row-start-2 lg:row-end-6 lg:m-auto col-span-1 z-30">
+					{{ utc_hero.hero_image }} 
 				</div>
 			{% endif %}
-
-				<div class="lg:col-start-3 md:col-start-1 lg:col-end-4 lg:row-start-2 lg:row-end-3 lg:ml-8 p-4 pb-0 lg:pb-4 z-30 self-end">
-		{% else %}
-		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utcheroright lg:grid-flow-row lg:mb-4 text-center">
+				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-3 lg:ml-8 p-4 z-30 self-end">
+	{% else %}
+		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-6 grid-flow-row lg:mb-4 text-center">
 			{% if utc_hero.hero_image %}
-				<div class="lg:col-start-3 lg:col-end-4 md:col-start-1 lg:row-start-2 lg:row-end-5 lg:m-auto lg:mt-8 z-30">
-				{{ utc_hero.hero_image }}
+				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto z-30">
+					{{ utc_hero.hero_image }}
 				</div>
 			{% endif %}
-		
-				<div class="lg:col-start-2 md:col-start-1 lg:col-end-2 lg:row-start-2 lg:row-end-3 lg:mr-8 pt-4 px-6 pb-0 lg:pb-4 col-span-1 z-30 self-end">
-		{% endif %}
-			{% if utc_hero.hero_tag %}
-				<p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">
-					{{ utc_hero.hero_tag }}
-				</p>
-				<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20" />
-			{% endif %}
-			{% if utc_hero.hero_title %}
-				<h2 class="text-left {{ title_color }}">
-					{{ utc_hero.hero_title }}
-				</h2>
-			{% endif %}
-			</div>
-			{% if utc_hero.hero_align == 'Left' %}
-			<div class="lg:col-start-3 md:col-start-1 lg:col-end-4 lg:row-start-3 lg:row-end-4 lg:ml-8 p-6 z-30 pt-0 lg:pt-4">
-			{% else %}
-			<div class="lg:col-start-2 md:col-start-1 lg:col-end-2 lg:row-start-3 lg:row-end-4 lg:mr-8 p-6 col-span-1 z-30 pt-0 lg:pt-4">
-			{% endif %}
-			{% if utc_hero.hero_text %}
-				<p class="text-left text-lg text-base">
-					{{ utc_hero.hero_text }}
-				</p>
-			{% endif %}
-			{% if utc_hero.hero_button_url %}
-				{% if utc_hero.hero_button_text %}
-					<p class="mt-6 text-right">
-						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out text-base hover:bg-gray-200 lg:hover:text-utc-new-blue-500 lg:hover:bg-white transform hover:scale-105 py-2 px-4 border border-utc-new-blue-500" aria-label="Read the release">
-							Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i></a>
+				<div class="lg:col-start-2 lg:col-end-2 lg:row-start-2 lg:row-end-3 lg:mr-8 p-4 pt-0 col-span-1 z-30 self-end">
+	{% endif %}
+					{% if utc_hero.hero_tag %}
+					<p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">
+						{{ utc_hero.hero_tag }}
+					</p>
+					<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20" />
+					{% endif %}
+					{% if utc_hero.hero_title %}
+					<h2 class="text-left {{ title_color }}">
+						{{ utc_hero.hero_title }}
+					</h2>
+					{% endif %}
+					</div>
+					{% if utc_hero.hero_align == 'Left' %}
+					<div class="lg:col-start-3 lg:col-end-4 lg:row-start-3 lg:row-end-4 lg:mr-8 lg:ml-8 p-4 pt-0 col-span-1 z-30">
+					{% else %}
+					<div class="lg:col-start-2 lg:col-end-3 lg:row-start-3 lg:row-end-4 lg:mr-8 p-4 pt-0 col-span-1 z-30">
+					{% endif %}
+					{% if utc_hero.hero_text %}
+					<p class="text-left text-lg text-base">
+						{{ utc_hero.hero_text}}
 					</p>
 					{% endif %}
+				{% if utc_hero.hero_button_url %}
+				{% if utc_hero.hero_button_text %}
+					<p class="my-6 text-right">
+						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out text-base hover:bg-gray-200 lg:hover:text-utc-new-blue-500 lg:hover:bg-white transform hover:scale-105 py-2 px-4 border border-utc-new-blue-500" aria-label="Read the release">
+							Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i>
+						</a>
+					</p>
+					</div>
 				{% endif %}
-
-				</div>
-
-			<div class="w-full h-full bg-cover bg-center z-10 md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-3" style="background-image: url({{ utc_hero.hero_bg }})">
-			
-				<div class="h-full w-full bg-opacity-90 {{ bg_color }}"></div>
-				</div>
-		
-
-
+				{% endif %}
+				
+			<div class="w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-3" style="background-image: url({{ utc_hero.hero_bg }})">
+				<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
+			</div>
 		</div>
-
-
 	{% endblock %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
@@ -1,4 +1,4 @@
-{% extends "block.html.twig" %}
+{% extends "block--utc-hero--full.html.twig" %}
 {#
 /**
  * @file Card Grid!
@@ -32,19 +32,18 @@
 	{# Sets colors for hero content depending on selection #}
 	{% if utc_hero.hero_color == 'Dark Blue' %}
 		{% set title_color = 'lg:text-white' %}
-		{% set body_color = 'lg:text-white' %}
-		{% set btn_border_color = "lg:border-white" %}
 		{% set bg_color = 'background-color:#112e51' %}
 		{% set bg1_opacity = '' %}
     	{% set bg2_opacity = 'opacity-90' %}
 	{% else %}
 		{% set title_color = 'text-utc-new-blue-500' %}
-		{% set body_color = 'text-base' %}
-		{% set btn_border_color = "lg:border-utc-new-blue-500" %}
 		{% set bg_color = 'background-color:#104dd4' %}
 		{% set bg1_opacity = 'opacity-20' %}
     	{% set bg2_opacity = 'opacity-20' %}
 	{% endif %}
+	{% set body_color = 'text-base' %}
+	{% set btn_border_color = "lg:border-utc-new-blue-500" %}
+	{% set btn_color = "lg:text-base" %} 
 		 
 	{% if utc_hero.hero_align == 'Left' %}
 		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-4 lg:grid-flow-row lg:mb-4 text-center">
@@ -63,39 +62,19 @@
 			{% endif %}
 				<div class="lg:col-start-2 lg:col-end-2 lg:row-start-2 lg:row-end-3 lg:mr-8 p-4 pt-0 col-span-1 z-30 self-end">
 	{% endif %}
-					{% if utc_hero.hero_tag %}
-					<p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">
-						{{ utc_hero.hero_tag }}
-					</p>
-					<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20" />
-					{% endif %}
-					{% if utc_hero.hero_title %}
-					<h2 class="text-left {{ title_color }}">
-						{{ utc_hero.hero_title }}
-					</h2>
-					{% endif %}
-					</div>
-					{% if utc_hero.hero_align == 'Left' %}
-					<div class="lg:col-start-3 lg:col-end-4 lg:row-start-3 lg:row-end-4 lg:mr-8 lg:ml-8 p-4 pt-0 col-span-1 z-30">
-					{% else %}
-					<div class="lg:col-start-2 lg:col-end-3 lg:row-start-3 lg:row-end-4 lg:mr-8 p-4 pt-0 col-span-1 z-30">
-					{% endif %}
-					{% if utc_hero.hero_text %}
-					<p class="text-left text-lg text-base">
-						{{ utc_hero.hero_text}}
-					</p>
-					{% endif %}
-				{% if utc_hero.hero_button_url %}
-				{% if utc_hero.hero_button_text %}
-					<p class="my-6 text-right">
-						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out text-base hover:bg-gray-200 lg:hover:text-utc-new-blue-500 lg:hover:bg-white transform hover:scale-105 py-2 px-4 border border-utc-new-blue-500" aria-label="Read the release">
-							Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i>
-						</a>
-					</p>
-					</div>
-				{% endif %}
-				{% endif %}
-				
+				{% block herotagtitle %}
+					{{ parent() }}
+				{% endblock herotagtitle %}
+				</div>
+			{% if utc_hero.hero_align == 'Left' %}
+				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-3 lg:row-end-4 lg:mr-8 lg:ml-8 p-4 pt-0 col-span-1 z-30">
+			{% else %}
+				<div class="lg:col-start-2 lg:col-end-3 lg:row-start-3 lg:row-end-4 lg:mr-8 p-4 pt-0 col-span-1 z-30">
+			{% endif %}
+				{% block herotextbutton %}
+					{{ parent() }}
+				{% endblock herotextbutton %}
+				</div>
 			<div class="w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-3" style="background-image: url({{ utc_hero.hero_bg }})">
 				<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
 			</div>

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-center.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-center.html.twig
@@ -1,0 +1,77 @@
+{% extends "block--utc-hero--full.html.twig" %}
+{#
+/**
+ * @file Card Grid!
+ * Implements a hero block in dark blue
+ *
+ *
+ * Available variables:
+ */
+ *
+ * This template pulls in the variables to add to the cards. 
+ * References the block--utc-card-base.html.twig to create the individual cards in this grid.
+#}
+
+{% block content %}
+	{% set rendered_content = content|render %}
+	{# Sets variable to trigger content render array. #}
+	{# hero_button_link: content.field_hero_button|field_value, #}
+	{% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %}
+	{% set utc_hero = {
+		hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_image_select)["#object"].field_image_url.value,
+		hero_align: content["#block_content"].field_hero_align.0.value,
+		hero_color: content["#block_content"].field_hero_color.0.value,
+		hero_tag: content.field_hero_tag|field_value,
+		hero_title: content.field_hero_title|field_value,
+		hero_image: content.field_utc_media|field_value,
+		hero_text: content.field_hero_text|field_value,
+		hero_button_text: content.field_hero_button.0['#title'],
+		hero_button_url: content.field_hero_button.0['#url'],
+    } %}
+	{# Sets colors for hero content depending on selection #}
+	{% if utc_hero.hero_color == 'Dark Blue' %}
+		{% set title_color = 'lg:text-white' %}
+		{% set body_color = 'lg:text-white' %}
+		{% set btn_border_color = "lg:border-white" %}
+		{% set bg_color = 'background-color:#112e51' %}
+		{% set bg1_opacity = '' %}
+    	{% set bg2_opacity = 'opacity-90' %}
+	{% else %}
+		{% set title_color = 'text-utc-new-blue-500' %}
+		{% set body_color = 'text-base' %}
+		{% set btn_border_color = "lg:border-utc-new-blue-500" %}
+		{% set bg_color = 'background-color:#104dd4' %}
+		{% set bg1_opacity = 'opacity-20' %}
+    	{% set bg2_opacity = 'opacity-20' %}
+	{% endif %}
+		 
+	{% if utc_hero.hero_align == 'Left' %}
+		<div class="lg:grid lg:grid-rows-utcherocenter lg:grid-cols-utcherocenter lg:gap-y-4 lg:grid-flow-row lg:mb-4 text-center">
+			{% if utc_hero.hero_image %}
+				<div class="lg:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-4 lg:m-auto col-span-1 z-30">
+					{{ utc_hero.hero_image }} 
+				</div>
+			{% endif %}
+				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-5 lg:my-auto lg:ml-14 p-4 z-30">
+	{% else %}
+		<div class="lg:grid lg:grid-rows-utcherocenter lg:grid-cols-utcherocenter lg:gap-y-6 grid-flow-row lg:mb-4 text-center">
+			{% if utc_hero.hero_image %}
+				<div class="lg:col-start-3 lg:col-end-5 lg:row-start-2 lg:row-end-4 lg:m-auto z-30">
+					{{ utc_hero.hero_image }}
+				</div>
+			{% endif %}
+				<div class="lg:col-start-2 lg:col-end-2 lg:row-start-1 lg:row-end-5 lg:mr-14 lg:my-auto py-4 px-6 col-span-1 z-30">
+	{% endif %}
+					{% block herocontent %}
+						{{ parent() }}
+					{% endblock %}
+				</div>
+		{% if utc_hero.hero_align == 'Left' %}
+			<div class="md:col-start-2 md:col-end-5 md:row-start-1 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10" style="background-image: url({{ utc_hero.hero_bg }})">
+		{% else %}
+			<div class="md:col-start-1 md:col-end-4 md:row-start-1 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10" style="background-image: url({{ utc_hero.hero_bg }})">
+		{% endif %}
+				<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
+			</div>
+		</div>
+	{% endblock %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-reverse.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-reverse.html.twig
@@ -1,0 +1,97 @@
+{% extends "block.html.twig" %}
+{#
+/**
+ * @file Card Grid!
+ * Implements a hero block in dark blue
+ *
+ *
+ * Available variables:
+ */
+ *
+ * This template pulls in the variables to add to the cards. 
+ * References the block--utc-card-base.html.twig to create the individual cards in this grid.
+#}
+
+{% block content %}
+	{% set rendered_content = content|render %}
+	{# Sets variable to trigger content render array. #}
+	{# hero_button_link: content.field_hero_button|field_value, #}
+	{% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %}
+	{% set utc_hero = {
+	hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_image_select)["#object"].field_image_url.value,
+	hero_align: content["#block_content"].field_hero_align.0.value,
+	hero_color: content["#block_content"].field_hero_color.0.value,
+	hero_tag: content.field_hero_tag|field_value,
+    hero_title: content.field_hero_title|field_value,
+    hero_image: content.field_utc_media|field_value,
+    hero_text: content.field_hero_text|field_value,
+    hero_button_text: content.field_hero_button.0['#title'],
+    hero_button_url: content.field_hero_button.0['#url'],
+    } %}
+
+	{# Sets colors for hero content depending on selection #}
+	{% if utc_hero.hero_color == 'Dark Blue' %}
+		{% set title_color = 'lg:text-white' %}
+		{% set body_color = 'lg:text-white' %}
+		{% set btn_border_color = "lg:border-white" %}
+		{% set bg_color = 'background-color:#112e51' %}
+		{% set bg1_opacity = '' %}
+    	{% set bg2_opacity = 'opacity-90' %}
+	{% else %}
+		{% set title_color = 'text-utc-new-blue-500' %}
+		{% set body_color = 'text-base' %}
+		{% set btn_border_color = "lg:border-utc-new-blue-500" %}
+		{% set bg_color = 'background-color:#104dd4' %}
+		{% set bg1_opacity = 'opacity-20' %}
+    	{% set bg2_opacity = 'opacity-20' %}
+	{% endif %}
+		 
+	{% if utc_hero.hero_align == 'Left' %}
+		<div class="lg:grid lg:grid-rows-utcheroreverse lg:grid-cols-utchero lg:gap-y-4 lg:grid-flow-row lg:mb-4 text-center">
+			{% if utc_hero.hero_image %}
+				<div class="lg:col-start-2 lg:col-end-3 lg:row-start-1 lg:row-end-4 lg:m-auto col-span-1 z-30">
+					{{ utc_hero.hero_image }} 
+				</div>
+			{% endif %}
+				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-5 lg:my-auto lg:ml-8 p-4 z-30">
+	{% else %}
+		<div class="lg:grid lg:grid-rows-utcheroreverse lg:grid-cols-utcheroright lg:gap-y-6 grid-flow-row lg:mb-4 text-center">
+			{% if utc_hero.hero_image %}
+				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:m-auto z-30">
+					{{ utc_hero.hero_image }}
+				</div>
+			{% endif %}
+				<div class="lg:col-start-2 lg:col-end-2 lg:row-start-2 lg:row-end-5 lg:mr-8 lg:my-auto py-4 px-6 col-span-1 z-30">
+	{% endif %}
+					{% if utc_hero.hero_tag %}
+					<p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">
+						{{ utc_hero.hero_tag }}
+					</p>
+					<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20" />
+					{% endif %}
+					{% if utc_hero.hero_title %}
+					<h2 class="text-left {{ title_color }}">
+						{{ utc_hero.hero_title }}
+					</h2>
+					{% endif %}
+					{% if utc_hero.hero_text %}
+					<p class="text-left text-lg text-base {{ body_color }}">
+						{{ utc_hero.hero_text}}
+					</p>
+					{% endif %}
+				{% if utc_hero.hero_button_url %}
+				{% if utc_hero.hero_button_text %}
+					<p class="my-6 text-right">
+						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out {{ body_color }} hover:bg-gray-200 lg:hover:text-utc-new-blue-500 lg:hover:bg-white transform hover:scale-105 py-2 px-4 border {{ btn_border_color }} border-utc-new-blue-500" aria-label="Read the release">
+							Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i>
+						</a>
+					</p>
+					<p>
+				{% endif %}
+				{% endif %}
+				</div>
+			<div class="w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 md:col-start-1 md:col-end-5 md:row-start-2 md:row-end-5" style="background-image: url({{ utc_hero.hero_bg }})">
+				<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
+			</div>
+		</div>
+	{% endblock %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-reverse.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-reverse.html.twig
@@ -1,4 +1,4 @@
-{% extends "block.html.twig" %}
+{% extends "block--utc-hero--full.html.twig" %}
 {#
 /**
  * @file Card Grid!
@@ -18,17 +18,16 @@
 	{# hero_button_link: content.field_hero_button|field_value, #}
 	{% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %}
 	{% set utc_hero = {
-	hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_image_select)["#object"].field_image_url.value,
-	hero_align: content["#block_content"].field_hero_align.0.value,
-	hero_color: content["#block_content"].field_hero_color.0.value,
-	hero_tag: content.field_hero_tag|field_value,
-    hero_title: content.field_hero_title|field_value,
-    hero_image: content.field_utc_media|field_value,
-    hero_text: content.field_hero_text|field_value,
-    hero_button_text: content.field_hero_button.0['#title'],
-    hero_button_url: content.field_hero_button.0['#url'],
+		hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_image_select)["#object"].field_image_url.value,
+		hero_align: content["#block_content"].field_hero_align.0.value,
+		hero_color: content["#block_content"].field_hero_color.0.value,
+		hero_tag: content.field_hero_tag|field_value,
+		hero_title: content.field_hero_title|field_value,
+		hero_image: content.field_utc_media|field_value,
+		hero_text: content.field_hero_text|field_value,
+		hero_button_text: content.field_hero_button.0['#title'],
+		hero_button_url: content.field_hero_button.0['#url'],
     } %}
-
 	{# Sets colors for hero content depending on selection #}
 	{% if utc_hero.hero_color == 'Dark Blue' %}
 		{% set title_color = 'lg:text-white' %}
@@ -63,34 +62,11 @@
 			{% endif %}
 				<div class="lg:col-start-2 lg:col-end-2 lg:row-start-2 lg:row-end-5 lg:mr-8 lg:my-auto py-4 px-6 col-span-1 z-30">
 	{% endif %}
-					{% if utc_hero.hero_tag %}
-					<p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">
-						{{ utc_hero.hero_tag }}
-					</p>
-					<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20" />
-					{% endif %}
-					{% if utc_hero.hero_title %}
-					<h2 class="text-left {{ title_color }}">
-						{{ utc_hero.hero_title }}
-					</h2>
-					{% endif %}
-					{% if utc_hero.hero_text %}
-					<p class="text-left text-lg text-base {{ body_color }}">
-						{{ utc_hero.hero_text}}
-					</p>
-					{% endif %}
-				{% if utc_hero.hero_button_url %}
-				{% if utc_hero.hero_button_text %}
-					<p class="my-6 text-right">
-						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out {{ body_color }} hover:bg-gray-200 lg:hover:text-utc-new-blue-500 lg:hover:bg-white transform hover:scale-105 py-2 px-4 border {{ btn_border_color }} border-utc-new-blue-500" aria-label="Read the release">
-							Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i>
-						</a>
-					</p>
-					<p>
-				{% endif %}
-				{% endif %}
+					{% block herocontent %}
+						{{ parent() }}
+					{% endblock %}
 				</div>
-			<div class="w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 md:col-start-1 md:col-end-5 md:row-start-2 md:row-end-5" style="background-image: url({{ utc_hero.hero_bg }})">
+			<div class="md:col-start-1 md:col-end-5 md:row-start-2 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10" style="background-image: url({{ utc_hero.hero_bg }})">
 				<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
 			</div>
 		</div>

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
@@ -38,26 +38,23 @@
 	{% set body_color = 'text-base' %}
 	{% set bg_color = 'bg-utc-new-blue-300' %}
 	{% endif %}
-
-
-
 		 
 		{% if utc_hero.hero_align == 'Left' %}
-		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-8 lg:grid-flow-row lg:mb-4 2xl:grid-cols-utcherolarge text-center">
+		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-8 lg:grid-flow-row lg:mb-4 text-center">
 			{% if utc_hero.hero_image %}
-				<div class="2xl:col-start-2 lg:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto col-span-1 z-30">
+				<div class="lg:col-start-2 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto col-span-1 z-30">
 				{{ utc_hero.hero_image }} 
 				</div>
 			{% endif %}
-				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:my-auto lg:mx-8 p-4 z-30">
+				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:my-auto lg:ml-8 p-4 z-30">
 		{% else %}
-		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-8 grid-flow-row lg:mb-4 2xl:grid-cols-utcherolargeright text-center">
+		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-8 grid-flow-row lg:mb-4 text-center">
 			{% if utc_hero.hero_image %}
-				<div class="lg:col-start-3 lg:col-end-5 2xl:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto z-30">
+				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto z-30">
 				{{ utc_hero.hero_image }}
 				</div>
 			{% endif %}
-				<div class="2xl:col-start-2 lg:col-start-2 lg:col-end-2 lg:row-start-1 lg:row-end-4 lg:my-auto lg:mx-8 py-4 px-6 col-span-1 z-30">
+				<div class="2xl:col-start-2 lg:col-start-2 lg:col-end-2 lg:row-start-1 lg:row-end-4 lg:my-auto lg:mr-8 py-4 px-6 col-span-1 z-30">
 		{% endif %}
 			{% if utc_hero.hero_tag %}
 				<p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">
@@ -77,8 +74,8 @@
 			{% endif %}
 			{% if utc_hero.hero_button_url %}
 				{% if utc_hero.hero_button_text %}
-					<p class="mt-6 xl:mr-16 text-right">
-						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out {{ body_color }} hover:bg-gray-200 lg:hover:text-utc-new-blue-500 lg:hover:bg-white transform hover:scale-105 py-2 px-4 border lg:border-white border-utc-new-blue-500 " aria-label="Read the release">
+					<p class="my-6 text-right">
+						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out {{ body_color }} hover:bg-gray-200 lg:hover:text-utc-new-blue-500 lg:hover:bg-white transform hover:scale-105 py-2 px-4 border lg:border-white border-utc-new-blue-500" aria-label="Read the release">
 							Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i></a>
 					</p>
 					<p>

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
@@ -28,68 +28,70 @@
     hero_button_text: content.field_hero_button.0['#title'],
     hero_button_url: content.field_hero_button.0['#url'],
     } %}
+
 	{# Sets colors for hero content depending on selection #}
 	{% if utc_hero.hero_color == 'Dark Blue' %}
-	{% set title_color = 'lg:text-white' %}
-	{% set body_color = 'lg:text-white' %}
-	{% set bg_color = 'bg-utc-new-blue-500' %}
+		{% set title_color = 'lg:text-white' %}
+		{% set body_color = 'lg:text-white' %}
+		{% set btn_border_color = "lg:border-white" %}
+		{% set bg_color = 'background-color:#112e51' %}
+		{% set bg1_opacity = '' %}
+    	{% set bg2_opacity = 'opacity-90' %}
 	{% else %}
-	{% set title_color = 'text-utc-new-blue-500' %}
-	{% set body_color = 'text-base' %}
-	{% set bg_color = 'bg-utc-new-blue-300' %}
+		{% set title_color = 'text-utc-new-blue-500' %}
+		{% set body_color = 'text-base' %}
+		{% set btn_border_color = "lg:border-utc-new-blue-500" %}
+		{% set bg_color = 'background-color:#104dd4' %}
+		{% set bg1_opacity = 'opacity-20' %}
+    	{% set bg2_opacity = 'opacity-20' %}
 	{% endif %}
 		 
-		{% if utc_hero.hero_align == 'Left' %}
-		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-8 lg:grid-flow-row lg:mb-4 text-center">
+	{% if utc_hero.hero_align == 'Left' %}
+		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-4 lg:grid-flow-row lg:mb-4 text-center">
 			{% if utc_hero.hero_image %}
-				<div class="lg:col-start-2 lg:col-end-3 lg:row-start-2 lg:row-end-5 lg:m-auto col-span-1 z-30">
-				{{ utc_hero.hero_image }} 
+				<div class="lg:col-start-2 lg:col-end-3 lg:row-start-2 lg:row-end-6 lg:m-auto col-span-1 z-30">
+					{{ utc_hero.hero_image }} 
 				</div>
 			{% endif %}
-				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:my-auto lg:ml-8 p-4 z-30">
-		{% else %}
-		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-8 grid-flow-row lg:mb-4 text-center">
+				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-4 lg:my-auto lg:ml-8 p-4 z-30">
+	{% else %}
+		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-6 grid-flow-row lg:mb-4 text-center">
 			{% if utc_hero.hero_image %}
 				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto z-30">
-				{{ utc_hero.hero_image }}
+					{{ utc_hero.hero_image }}
 				</div>
 			{% endif %}
-				<div class="2xl:col-start-2 lg:col-start-2 lg:col-end-2 lg:row-start-1 lg:row-end-4 lg:my-auto lg:mr-8 py-4 px-6 col-span-1 z-30">
-		{% endif %}
-			{% if utc_hero.hero_tag %}
-				<p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">
-					{{ utc_hero.hero_tag }}
-				</p>
-				<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20" />
-			{% endif %}
-			{% if utc_hero.hero_title %}
-				<h2 class="text-left {{ title_color }}">
-					{{ utc_hero.hero_title }}
-				</h2>
-			{% endif %}
-			{% if utc_hero.hero_text %}
-				<p class="text-left text-lg text-base {{ body_color }}">
-					{{ utc_hero.hero_text}}
-				</p>
-			{% endif %}
-			{% if utc_hero.hero_button_url %}
+				<div class="lg:col-start-2 lg:col-end-2 lg:row-start-2 lg:row-end-4 lg:mr-8 lg:my-auto py-4 px-6 col-span-1 z-30">
+	{% endif %}
+					{% if utc_hero.hero_tag %}
+					<p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">
+						{{ utc_hero.hero_tag }}
+					</p>
+					<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20" />
+					{% endif %}
+					{% if utc_hero.hero_title %}
+					<h2 class="text-left {{ title_color }}">
+						{{ utc_hero.hero_title }}
+					</h2>
+					{% endif %}
+					{% if utc_hero.hero_text %}
+					<p class="text-left text-lg text-base {{ body_color }}">
+						{{ utc_hero.hero_text}}
+					</p>
+					{% endif %}
+				{% if utc_hero.hero_button_url %}
 				{% if utc_hero.hero_button_text %}
 					<p class="my-6 text-right">
-						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out {{ body_color }} hover:bg-gray-200 lg:hover:text-utc-new-blue-500 lg:hover:bg-white transform hover:scale-105 py-2 px-4 border lg:border-white border-utc-new-blue-500" aria-label="Read the release">
-							Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i></a>
+						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out {{ body_color }} hover:bg-gray-200 lg:hover:text-utc-new-blue-500 lg:hover:bg-white transform hover:scale-105 py-2 px-4 border {{ btn_border_color }} border-utc-new-blue-500" aria-label="Read the release">
+							Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i>
+						</a>
 					</p>
 					<p>
-					{% endif %}
+				{% endif %}
 				{% endif %}
 				</div>
-
-			<div class="w-full h-full bg-cover bg-center z-10 md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-4" style="background-image: url({{ utc_hero.hero_bg }})">
-			
-				<div class="h-full w-full bg-opacity-90 {{ bg_color }}"></div>
-				</div>
-
-
+			<div class="w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-4" style="background-image: url({{ utc_hero.hero_bg }})">
+				<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
+			</div>
 		</div>
-
-
 	{% endblock %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
@@ -18,17 +18,16 @@
 	{# hero_button_link: content.field_hero_button|field_value, #}
 	{% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %}
 	{% set utc_hero = {
-	hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_image_select)["#object"].field_image_url.value,
-	hero_align: content["#block_content"].field_hero_align.0.value,
-	hero_color: content["#block_content"].field_hero_color.0.value,
-	hero_tag: content.field_hero_tag|field_value,
-    hero_title: content.field_hero_title|field_value,
-    hero_image: content.field_utc_media|field_value,
-    hero_text: content.field_hero_text|field_value,
-    hero_button_text: content.field_hero_button.0['#title'],
-    hero_button_url: content.field_hero_button.0['#url'],
+		hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_image_select)["#object"].field_image_url.value,
+		hero_align: content["#block_content"].field_hero_align.0.value,
+		hero_color: content["#block_content"].field_hero_color.0.value,
+		hero_tag: content.field_hero_tag|field_value,
+		hero_title: content.field_hero_title|field_value,
+		hero_image: content.field_utc_media|field_value,
+		hero_text: content.field_hero_text|field_value,
+		hero_button_text: content.field_hero_button.0['#title'],
+		hero_button_url: content.field_hero_button.0['#url'],
     } %}
-
 	{# Sets colors for hero content depending on selection #}
 	{% if utc_hero.hero_color == 'Dark Blue' %}
 		{% set title_color = 'lg:text-white' %}
@@ -45,7 +44,7 @@
 		{% set bg1_opacity = 'opacity-20' %}
     	{% set bg2_opacity = 'opacity-20' %}
 	{% endif %}
-		 
+	{# image on left #}	 
 	{% if utc_hero.hero_align == 'Left' %}
 		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-4 lg:grid-flow-row lg:mb-4 text-center">
 			{% if utc_hero.hero_image %}
@@ -55,6 +54,7 @@
 			{% endif %}
 				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:my-auto lg:ml-8 p-4 z-30">
 	{% else %}
+	{# image on right #}	
 		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-6 grid-flow-row lg:mb-4 text-center">
 			{% if utc_hero.hero_image %}
 				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto z-30">
@@ -63,35 +63,43 @@
 			{% endif %}
 				<div class="lg:col-start-2 lg:col-end-2 lg:row-start-1 lg:row-end-4 lg:mr-8 lg:my-auto py-4 px-6 col-span-1 z-30">
 	{% endif %}
+				{% block herocontent %}
+					{% block herotagtitle %}
 					{% if utc_hero.hero_tag %}
-					<p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">
-						{{ utc_hero.hero_tag }}
-					</p>
-					<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20" />
+						<p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">
+							{{ utc_hero.hero_tag }}
+						</p>
+						<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20" />
 					{% endif %}
 					{% if utc_hero.hero_title %}
-					<h2 class="text-left {{ title_color }}">
-						{{ utc_hero.hero_title }}
-					</h2>
+						<h2 class="text-left {{ title_color }}">
+							{{ utc_hero.hero_title }}
+						</h2>
 					{% endif %}
-					{% if utc_hero.hero_text %}
-					<p class="text-left text-lg text-base {{ body_color }}">
-						{{ utc_hero.hero_text}}
-					</p>
-					{% endif %}
-				{% if utc_hero.hero_button_url %}
-				{% if utc_hero.hero_button_text %}
-					<p class="my-6 text-right">
-						<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out {{ body_color }} hover:bg-gray-200 lg:hover:text-utc-new-blue-500 lg:hover:bg-white transform hover:scale-105 py-2 px-4 border {{ btn_border_color }} border-utc-new-blue-500" aria-label="Read the release">
-							Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i>
-						</a>
-					</p>
-					<p>
-				{% endif %}
-				{% endif %}
+					{% endblock herotagtitle %}
+					{% block herotextbutton %}
+						{% if utc_hero.hero_text %}
+							<p class="text-left text-lg text-base {{ body_color }}">
+								{{ utc_hero.hero_text}}
+							</p>
+						{% endif %}
+						{% if utc_hero.hero_button_url %}
+						{% if utc_hero.hero_button_text %}
+							<p class="my-6 text-right">
+								<a href="{{ utc_hero.hero_button_url}}" class="font-semibold transition duration-500 ease-in-out {{ body_color }} hover:bg-gray-200 lg:hover:text-utc-new-blue-500 lg:hover:bg-white transform hover:scale-105 py-2 px-4 border {{ btn_border_color }} border-utc-new-blue-500" aria-label="Read the release">
+									Learn more <i class="fas fa-angle-right text-utc-new-gold-500 font-semibold ml-1"></i>
+								</a>
+							</p>
+
+						{% endif %}
+						{% endif %}
+					{% endblock herotextbutton %}
+				{% endblock herocontent %}
 				</div>
-			<div class="w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-4" style="background-image: url({{ utc_hero.hero_bg }})">
-				<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
-			</div>
+				{% block herobackground %}
+					<div class="w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-4" style="background-image: url({{ utc_hero.hero_bg }})">
+						<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
+					</div>
+				{% endblock herobackground %}
 		</div>
-	{% endblock %}
+{% endblock %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
@@ -53,7 +53,7 @@
 					{{ utc_hero.hero_image }} 
 				</div>
 			{% endif %}
-				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-4 lg:my-auto lg:ml-8 p-4 z-30">
+				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:my-auto lg:ml-8 p-4 z-30">
 	{% else %}
 		<div class="lg:grid lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-6 grid-flow-row lg:mb-4 text-center">
 			{% if utc_hero.hero_image %}
@@ -61,7 +61,7 @@
 					{{ utc_hero.hero_image }}
 				</div>
 			{% endif %}
-				<div class="lg:col-start-2 lg:col-end-2 lg:row-start-2 lg:row-end-4 lg:mr-8 lg:my-auto py-4 px-6 col-span-1 z-30">
+				<div class="lg:col-start-2 lg:col-end-2 lg:row-start-1 lg:row-end-4 lg:mr-8 lg:my-auto py-4 px-6 col-span-1 z-30">
 	{% endif %}
 					{% if utc_hero.hero_tag %}
 					<p class="text-left font-semibold tracking-wide uppercase text-lg {{ body_color }}">

--- a/source/default/tailwind.config.js
+++ b/source/default/tailwind.config.js
@@ -34,11 +34,13 @@ module.exports = {
         // Adds a custom template for the utc hero block
         'utchero': '40px 1fr 1fr 70px',
         'utcheroreverse': '70px 1fr 1fr 40px',
+        'utcherocenter': '25px 1fr 1fr 25px',
       },
       gridTemplateColumns: {
         // Adds a custom template for the utc hero block
         'utchero': '1fr 60% 35% 1fr',
         'utcheroright': '1fr 35% 60% 1fr',
+        'utcherocenter': '1fr 45% 45% 1fr',
       }
     },
     minHeight: {

--- a/source/default/tailwind.config.js
+++ b/source/default/tailwind.config.js
@@ -33,6 +33,7 @@ module.exports = {
       gridTemplateRows: {
         // Adds a custom template for the utc hero block
         'utchero': '40px 1fr 1fr 70px',
+        'utcheroreverse': '70px 1fr 1fr 40px',
       },
       gridTemplateColumns: {
         // Adds a custom template for the utc hero block

--- a/source/default/tailwind.config.js
+++ b/source/default/tailwind.config.js
@@ -28,7 +28,7 @@ module.exports = {
   theme: {
     colors,
     customForms,
-    fontFamily,
+    fontFamily, 
     extend: {
       gridTemplateRows: {
         // Adds a custom template for the utc hero block
@@ -36,10 +36,8 @@ module.exports = {
       },
       gridTemplateColumns: {
         // Adds a custom template for the utc hero block
-        'utchero': '1fr 1fr 1fr',
-        'utcheroright': '10px 1fr 1fr 1fr',
-        'utcherolarge': '1fr minmax(min-content,120rem) minmax(min-content,50rem) 1fr',
-        'utcherolargeright': '1fr minmax(min-content,50rem) minmax(min-content,120rem) 1fr',
+        'utchero': '1fr minmax(min-content,55%) minmax(min-content,40%) 1fr',
+        'utcheroright': '1fr minmax(min-content,40%) minmax(min-content,55%) 1fr',
       }
     },
     minHeight: {

--- a/source/default/tailwind.config.js
+++ b/source/default/tailwind.config.js
@@ -32,12 +32,12 @@ module.exports = {
     extend: {
       gridTemplateRows: {
         // Adds a custom template for the utc hero block
-        'utchero': '30px 1fr 1fr 30px',
+        'utchero': '40px 1fr 1fr 70px',
       },
       gridTemplateColumns: {
         // Adds a custom template for the utc hero block
-        'utchero': '1fr minmax(min-content,55%) minmax(min-content,40%) 1fr',
-        'utcheroright': '1fr minmax(min-content,40%) minmax(min-content,55%) 1fr',
+        'utchero': '1fr 60% 35% 1fr',
+        'utcheroright': '1fr 35% 60% 1fr',
       }
     },
     minHeight: {


### PR DESCRIPTION
This PR adds a few options for the hero and fixes the margin per our discussion:

- Adds a "Full Center" view mode to vertically align image in center of banner.
- Adds a "Full Reverse" view mode to vertically align image at top of banner.
- Adjusts margin and grid for current Full and Default view modes.
- Adjusts lighter blue color per Bridget's suggestion.

We can take away some of these options if it's too much (and too much potential for misuse). Just thought I'd try out a few options for when these are added in different parts of a page.

Examples:

<img width="1741" alt="Screen Shot 2021-07-04 at 5 10 33 PM" src="https://user-images.githubusercontent.com/50490141/124399662-e6594480-dcea-11eb-840c-0be274811193.png">
<img width="1741" alt="Screen Shot 2021-07-04 at 5 11 12 PM" src="https://user-images.githubusercontent.com/50490141/124399665-e9eccb80-dcea-11eb-8906-f661a858198a.png">
<img width="1741" alt="Screen Shot 2021-07-04 at 5 11 05 PM" src="https://user-images.githubusercontent.com/50490141/124399670-eeb17f80-dcea-11eb-932a-78abbd360009.png">
<img width="1741" alt="Screen Shot 2021-07-04 at 5 10 59 PM" src="https://user-images.githubusercontent.com/50490141/124399673-f07b4300-dcea-11eb-92e8-d32557c1efd3.png">
<img width="1741" alt="Screen Shot 2021-07-04 at 5 10 47 PM" src="https://user-images.githubusercontent.com/50490141/124399675-f3763380-dcea-11eb-8bd2-b7a0958adfe8.png">
<img width="1741" alt="Screen Shot 2021-07-04 at 5 10 41 PM" src="https://user-images.githubusercontent.com/50490141/124399676-f53ff700-dcea-11eb-96cf-cb6dd784c006.png">
