### PR TITLE
fix/UTC-1790-layout-builder-contrast-issue

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/layout-builder.css
+++ b/source/default/_patterns/00-protons/legacy/css/layout-builder.css
@@ -15,7 +15,6 @@
 #drupal-off-canvas .layout-builder-configure-section .form-item .description,
 #drupal-off-canvas .layout-builder-configure-section .details-description,
 #drupal-off-canvas .layout-builder-configure-section *, 
-#drupal-off-canvas .layout-builder-configure-section *:not(div),
 #drupal-off-canvas .layout-selection .description,
 #drupal-off-canvas .layout-selection .form-item .description,
 #drupal-off-canvas .layout-selection .details-description,
@@ -23,6 +22,21 @@
 #drupal-off-canvas .layout-selection *:not(div)
  {
   color: white !important;
+}
+
+#drupal-off-canvas .form-select,
+#drupal-off-canvas .form-text,
+#drupal-off-canvas .form-tel,
+#drupal-off-canvas .form-email,
+#drupal-off-canvas .form-url,
+#drupal-off-canvas .form-search,
+#drupal-off-canvas .form-number,
+#drupal-off-canvas .form-color,
+#drupal-off-canvas .form-file,
+#drupal-off-canvas .form-textarea,
+#drupal-off-canvas .form-date,
+#drupal-off-canvas .form-time {
+  color: #333 !important;
 }
 
 #drupal-off-canvas .layout-builder-configure-section label {


### PR DESCRIPTION
Fixes UTC-1790.

This should fix the contrast issue on layout builder options. It's still a hacky solution to solve that and keep the higher contrast on the descriptions...ultimately...when we are ready I think it'd be good to look at possibly removing themag files that are causing this problem so we can revert this subpar solution I've added. ;)

<img width="264" alt="Screen Shot 2021-07-25 at 10 43 58 PM" src="https://user-images.githubusercontent.com/50490141/126926247-9f6b95a2-435a-47fc-9c9d-3e152ab03096.png">
