### PR TITLE
Hotfix/utc 279 open active submenus in sidebar

### DIFF
--- a/apps/drupal-default/particle_theme/templates/navigation/menu--utc-sidemenu.html.twig
+++ b/apps/drupal-default/particle_theme/templates/navigation/menu--utc-sidemenu.html.twig
@@ -40,7 +40,7 @@
           'menu-item-sidemenu',
           item.is_expanded ? 'menu-item--expanded',
           item.is_collapsed ? 'menu-item--collapsed',
-          item.in_active_trail ? 'menu-item--active-trail',
+          item.in_active_trail ? 'menu-item--active-trail show-sub',
       ]
       %}
       <li{{ item.attributes.addClass(classes) }}>

--- a/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
+++ b/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
@@ -1,123 +1,157 @@
-.utc-sidebar ol, .utc-sidebar ul {
-  list-style: none;
-  padding-left: 0;
+.utc-sidebar ol,
+.utc-sidebar ul {
+    list-style: none;
+    padding-left: 0;
 }
-.utc-sidebar ol li, .utc-sidebar ul li {
-  margin-bottom: 0.3em;
+
+.utc-sidebar ol li,
+.utc-sidebar ul li {
+    margin-bottom: 0.3em;
 }
-.utc-sidebar ol li ul li, .utc-sidebar ul li ul li {
-  margin: 0.3em auto;
+
+.utc-sidebar ol li ul li,
+.utc-sidebar ul li ul li {
+    margin: 0.3em auto;
 }
-.utc-sidebar ol li ul li:first-child, .utc-sidebar ul li ul li:first-child {
-  border-top: none;
+
+.utc-sidebar ol li ul li:first-child,
+.utc-sidebar ul li ul li:first-child {
+    border-top: none;
 }
-.utc-sidebar ol li ul li ul li, .utc-sidebar ul li ul li ul li {
-  margin: 0.3em auto;
+
+.utc-sidebar ol li ul li ul li,
+.utc-sidebar ul li ul li ul li {
+    margin: 0.3em auto;
 }
-.utc-sidebar ol li ul li ul li:first-child, .utc-sidebar ul li ul li ul li:first-child {
-  border-top: none;
+
+.utc-sidebar ol li ul li ul li:first-child,
+.utc-sidebar ul li ul li ul li:first-child {
+    border-top: none;
 }
+
 .utc-sidebar .sidebar-menu li {
-  position: relative;
+    position: relative;
 }
+
 .utc-sidebar .sidebar-menu li ul {
-  display: block;
-  max-height: 0;
-  overflow: hidden;
-  transition: all 0.3s ease;
+    display: block;
+    max-height: 0;
+    overflow: hidden;
+    transition: all 0.3s ease;
 }
+
 .utc-sidebar .sidebar-menu li ul .menu-item-sidemenu a {
-  @apply bg-gray-300;
+    @apply bg-gray-300;
 }
+
 .utc-sidebar .sidebar-menu li ul .menu-item-sidemenu a:hover {
-  @apply bg-gray-800;
-  @apply text-white;
-  /* color: white;
+    @apply bg-gray-800;
+    @apply text-white;
+    /* color: white;
   background-color: darkgray; */
 }
+
 .utc-sidebar .menu-btn {
-  /* background: lightblue; */
-  @apply bg-blue-100;
-  text-align: center;
-  cursor: s-resize;
+    /* background: lightblue; */
+    @apply bg-blue-100;
+    text-align: center;
+    cursor: s-resize;
 }
+
 .utc-sidebar .menu-btn img {
-  vertical-align: middle;
-  height: 50px;
+    vertical-align: middle;
+    height: 50px;
 }
-.utc-sidebar .menu-open, .utc-sidebar .sidebar-menu .open > ul {
-  max-height: 2000px;
+
+.utc-sidebar .menu-open,
+.utc-sidebar .sidebar-menu .open>ul,
+.utc-sidebar .sidebar-menu .show-sub>ul {
+    max-height: 2000px;
 }
-.utc-sidebar .sidebar-menu .open > .more i {
-  transform: rotate(-135deg);
+
+.utc-sidebar .sidebar-menu .open>.more i,
+.utc-sidebar .sidebar-menu .show-sub>.more i {
+    transform: rotate(-135deg);
 }
-.utc-sidebar .more{
-  /* color: gray; */
-   /* text-gray-800; */
-  @apply text-yellow-500;
-  transition: transform 0.3s;
-}
+
 .utc-sidebar .more {
-  float: right;
-  min-width: 8%;
-  cursor: move;
+    /* color: gray; */
+    /* text-gray-800; */
+    @apply text-yellow-500;
+    transition: transform 0.3s;
 }
+
+.utc-sidebar .more {
+    float: right;
+    min-width: 8%;
+    cursor: move;
+}
+
 .menu-item-sidemenu a {
-  @apply bg-white;
-  @apply text-utc-new-blue-500;
-  font-weight: 500;
-  border: 1px solid;
-  @apply border-gray-400;
-  display: block;
-  padding: 1rem 1.2rem;
+    @apply bg-white;
+    @apply text-utc-new-blue-500;
+    font-weight: 500;
+    border: 1px solid;
+    @apply border-gray-400;
+    display: block;
+    padding: 1rem 1.2rem;
 }
+
 .menu-item-sidemenu a:hover {
-  @apply bg-utc-new-blue-500;
-  @apply text-utc-new-gold-500;
-  text-decoration: none;
+    @apply bg-utc-new-blue-500;
+    @apply text-utc-new-gold-500;
+    text-decoration: none;
 }
+
+
 /* .utc-sidebar .menu-item-sidemenu a:hover .more {
   @apply text-white;
 } */
+
 .menu-item-sidemenu .is-active {
-  @apply bg-utc-new-blue-500 !important;
-  @apply text-utc-new-gold-500;
-  text-decoration: none;
+    @apply bg-utc-new-blue-500 !important;
+    @apply text-utc-new-gold-500;
+    text-decoration: none;
 }
+
+
 /* .utc-sidebar .menu-item--active-trail .more{
   @apply text-white;
   transition: transform 0.3s;
 } */
+
 @media (min-width: 991px) {
-  input#mobile_menu {
-    display: none;
- }
-  .section_menu {
-    display: none;
- }
+    input#mobile_menu {
+        display: none;
+    }
+    .section_menu {
+        display: none;
+    }
 }
+
 @media (max-width: 991px) {
-  .menu-content {
-    padding: 0 0 0 50px;
- }
-  .section_menu {
-    @apply bg-utc-new-gold-500;
-    padding: 5px 30px;
-    @apply text-gray-800;
-    cursor: pointer;
-    user-select: none;
- }
-  input#mobile_menu {
-    display: none;
- }
-  .utc-sidebar {
-    max-height: 0;
-    overflow: hidden;
- }
-  input:checked ~ .utc-sidebar {
-    max-height: 100%;
- }
+    .menu-content {
+        padding: 0 0 0 50px;
+    }
+    .section_menu {
+        @apply bg-utc-new-gold-500;
+        padding: 5px 30px;
+        @apply text-gray-800;
+        cursor: pointer;
+        user-select: none;
+    }
+    input#mobile_menu {
+        display: none;
+    }
+    .utc-sidebar {
+        max-height: 0;
+        overflow: hidden;
+    }
+    input:checked~.utc-sidebar {
+        max-height: 100%;
+    }
 }
+
 
 /* 
 HR MENU
@@ -125,5 +159,9 @@ HR MENU
   @apply bg-utc-new-blue-500 !important;
   text-decoration: none;
   /* background-color: #112e51 !important; */
-  /* color: #fdb736; */
-/* } */ 
+
+
+/* color: #fdb736; */
+
+
+/* } */

--- a/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
+++ b/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
@@ -65,12 +65,12 @@
 
 .utc-sidebar .menu-open,
 .utc-sidebar .sidebar-menu .open>ul,
-.utc-sidebar .sidebar-menu .show-sub>ul {
+.user-logged-in .utc-sidebar .sidebar-menu .show-sub>ul {
     max-height: 2000px;
 }
 
 .utc-sidebar .sidebar-menu .open>.more i,
-.utc-sidebar .sidebar-menu .show-sub>.more i {
+.user-logged-in .utc-sidebar .sidebar-menu .show-sub>.more i {
     transform: rotate(-135deg);
 }
 


### PR DESCRIPTION
# Pull Request

This fix is the Particle solution for issue #1722 in the UTCWeb/utccloud respository.

The issue is the sidebar navigation is no longer showing for authenticated user. The js function fires, but the `.open` class is removed from the `<li class="menu-item-sidemenu menu-item--expanded menu-item--active-trail"> ` on page load. It should have `<li class="menu-item-sidemenu menu-item--expanded menu-item--active-trail open"> ` which is the class that opens the submenu.

![Screen Shot 2021-07-27 at 5 12 11 PM](https://user-images.githubusercontent.com/82905787/127228255-6127355b-e43d-4789-9979-1fc9d436d391.png)

## Summary of Changes

Because the `.open` class is being removed, I have temporarily added a different class called `.show-sub` on active menu items. I have added this class to the css file in addition to the `.open` class. The menu now remains opened whether the page is cached or not.

Cached:
![Screen Shot 2021-07-27 at 4 50 43 PM](https://user-images.githubusercontent.com/82905787/127228501-66ac373f-b7aa-4e5b-8a98-6a84bcde46cd.png)

Not Cached:
![Screen Shot 2021-07-27 at 4 50 27 PM](https://user-images.githubusercontent.com/82905787/127228481-325f26a8-9587-46fc-889c-8aca9702a444.png)



