### PR TITLE
Fix/utc 1722 repair toggle submenu

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
+++ b/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
@@ -60,7 +60,7 @@
 .utc-sidebar .more {
   float: right;
   min-width: 8%;
-  cursor: move;
+  cursor: pointer;
 }
 .menu-item-sidemenu a {
   @apply bg-white;

--- a/source/default/_patterns/00-protons/legacy/js/utc-sidebar-menu.js
+++ b/source/default/_patterns/00-protons/legacy/js/utc-sidebar-menu.js
@@ -1,27 +1,34 @@
 (function($, Drupal, drupalSettings) {
-  "use strict";
+    "use strict";
 
-  Drupal.behaviors.sidebarmenu = {
-      attach: function(context, settings) {
-      $(".sidebar-menu li a").each(function () {
-        if ($(this).next().length > 0) {
-          $(this).addClass("parent");
-        };
-      })
-      var menux = $('.sidebar-menu li a.parent');
-      if ($('.more').length === 0) { 
-        $('<div class="more"><i class="fas fa-plus"></i></div>').insertBefore(menux);
-      };
-      $('.more').click(function () {
-        $(this).parent('li').toggleClass('open');
-      });
-      $('.menu-btn').click(function () {
-        $('nav').toggleClass('menu-open');
-      });
-      $('.sidebar-menu .menu-item--active-trail').each(function () {
-        $(this).addClass('open');
-      });
-           
-    }
-  };
+    Drupal.behaviors.sidebarmenu = {
+        attach: function(context, settings) {
+
+            $(".sidebar-menu li a").each(function() {
+                if ($(this).next().length > 0) {
+                    $(this).addClass("parent");
+                };
+            })
+            var menux = $('.sidebar-menu li a.parent');
+            if ($('.more').length === 0) {
+                $('<div class="more closed"><i class="fas fa-plus"></i></div>').insertBefore(menux);
+            };
+            $('.menu-btn').click(function() {
+                $('nav').toggleClass('menu-open');
+            });
+            $('.menu-item--expanded.menu-item--active-trail').each(function() {
+                $(this).addClass('open');
+                $(this).find('.more').removeClass('closed').addClass('open');
+            });
+            $(document).delegate('.more.open', 'click', function(){
+                $(this).removeClass('open').addClass('closed');
+                $(this).parent().removeClass('open');
+            });
+            $(document).delegate('.more.closed', 'click', function(){
+                $(this).removeClass('closed').addClass('open');
+                $(this).parent().addClass('open');
+            });
+
+        }
+    };
 }(jQuery, Drupal, drupalSettings));


### PR DESCRIPTION
When Section Editors are logged in, the submenu was not behaving properly. While we got the submenu to show upon page load with a previous PR, the toggle button still did not work in prod or test, and in local or dev when the web profiler module is turned off:

![toggle side navigation submenus not working](https://user-images.githubusercontent.com/82905787/127560687-c51cd7ab-f688-4044-bc42-6b85a0e86de3.gif)


For some reason conditional statements and toggles are not applying the classes to the parent when clicking .more indicator. The click fires, but nothing happens.


![toggle side navigation submenus not working no classes](https://user-images.githubusercontent.com/82905787/127561278-f7071a79-2386-46b7-beb7-f1cef5a5ccd2.gif)


So I did a work around with changing the click function to a delegate function and added classes to the .more based on the state of the menu.


![toggle side navigation submenus](https://user-images.githubusercontent.com/82905787/127561849-45ceb3a7-26fc-422c-832e-2b26cbd4af1c.gif)


Also, I changed the cursor to pointer when hovering over the .more indicator.