### PR TITLE
Add gray background to error pages, issue 1619

### DIFF
--- a/apps/drupal-default/particle_theme/includes/misc.theme.inc
+++ b/apps/drupal-default/particle_theme/includes/misc.theme.inc
@@ -42,3 +42,14 @@
 //   $variables['attributes']['class'][] = 'details';
 //   $variables['summary_attributes']['class'] = 'summary';
 // }
+/**
+ * @param $variables
+ */
+ //add body class to error pages for background change
+function particle_preprocess_html(&$variables)
+{
+    $statusCode = Drupal::request()->query->get('_exception_statuscode');
+    if (isset($statusCode) and (($statusCode == 404) or ($statusCode == 403))) {
+        $variables['attributes']['class'][] = 'page-' . $statusCode;
+    }
+}

--- a/source/default/_patterns/00-protons/index.js
+++ b/source/default/_patterns/00-protons/index.js
@@ -38,9 +38,8 @@ import './legacy/css/components/UTC-custom-blocks/_utc_directory.css';
 import './legacy/css/information-technology/_header.css';
 import './legacy/css/information-technology/_midpagewidget.css';
 import './legacy/css/digital_measures/tabbed.css';
-//import './legacy/css/pages/utc_about.css';
-//import './legacy/css/components/UTC-custom-blocks/_utc_youtube.css';
 import './legacy/css/pages/utc_homepages_options.css';
+import './legacy/css/pages/utc_error_pages.css';
 // import "./legacy/css/components/UTC-custom-blocks/";
 // import "./legacy/css/components/field/";
 

--- a/source/default/_patterns/00-protons/legacy/css/pages/utc_error_pages.css
+++ b/source/default/_patterns/00-protons/legacy/css/pages/utc_error_pages.css
@@ -1,0 +1,3 @@
+.page-403, .page-404 {
+    @apply bg-utc-new-blue-200;
+}


### PR DESCRIPTION
To add gray background to error pages, I first had to add a class to the body through the misc.theme.inc. Then I added a css page: utc_error_pages.css in legacy/pages/ and added that to the appropriate index.js. These pages have already been created in Production and assigned in config/system/site-information. Until this is deployed the background will be white, which should be fine. I will commit and push new configuration in utccloud after deployment.

Error 404

![Screen Shot 2021-08-12 at 10 46 12 AM](https://user-images.githubusercontent.com/82905787/129217646-5a6420c8-644f-442f-886b-14da9990569c.png)

Error 403

![Screen Shot 2021-08-12 at 10 45 42 AM](https://user-images.githubusercontent.com/82905787/129217667-7b821559-435c-46ec-a0e9-18b6d8e47ab0.png)
