### PR TITLE
Make submenus more ADA friendly by hiding the "+" from screen readers.

### DIFF
--- a/source/default/_patterns/00-protons/legacy/js/utc-sidebar-menu.js
+++ b/source/default/_patterns/00-protons/legacy/js/utc-sidebar-menu.js
@@ -11,7 +11,7 @@
             })
             var menux = $('.sidebar-menu li a.parent');
             if ($('.more').length === 0) {
-                $('<div class="more closed"><i class="fas fa-plus"></i></div>').insertBefore(menux);
+                $('<div aria-hidden="true" class="more closed"><i class="fas fa-plus"></i></div>').insertBefore(menux);
             };
             $('.menu-btn').click(function() {
                 $('nav').toggleClass('menu-open');


### PR DESCRIPTION
Because the submenus are always there for the screen readers whether the "+" has been clicked or not, and the parent is always clickable, the sidebar menus are already accessible. The confusion is the actual "+" toggle button. By adding an `aria-hidden="true"` attribute on that element's wrapper, that toggle will be ignored by screen readers. Essentially, the menu, as far as screen readers are concerned, is always open. 

**Menu closed:**

![Screen Shot 2021-08-20 at 8 32 21 AM](https://user-images.githubusercontent.com/82905787/130234778-b25b45d2-02e0-4787-b027-43c0e1c0019e.png)
:

**Code when the menu is closed:**

![Screen Shot 2021-08-20 at 8 32 08 AM](https://user-images.githubusercontent.com/82905787/130234875-37a0a9d9-64f5-4c65-9a5e-26c5bb82f36d.png)


**Menu open:**

![Screen Shot 2021-08-20 at 8 32 32 AM](https://user-images.githubusercontent.com/82905787/130234897-ab2c96af-43c9-4774-8d88-843ed1bd2c96.png)


**Code when the menu is open:**
Except for the actual toggled open/close class placed on the wrapper div around  "+", there is no difference in the menu.

![Screen Shot 2021-08-20 at 8 32 37 AM](https://user-images.githubusercontent.com/82905787/130234937-f8c6b712-f1de-47b5-9aaa-cd9bdd563758.png)


https://a11y-guidelines.orange.com/en/web/components-examples/accessible-hiding/
