### PR TITLE
Add placeholder option for each card

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--utc-card-base.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-card-base.html.twig
@@ -30,16 +30,30 @@
 
 {# could be the base card template in a design system #}
 
-{% set card_classes = [
-  'utc-card-2',
-  'h-100',
-  card_type ? 'utc-card-2--' ~ card_type,
-  card_color ? 'utc-card-2--' ~ card_color : 'utc-card-2--white',
-  card_width ? 'utc-card-2--w-' ~ card_width,
-  text_alignment ? 'utc-card-2--align-' ~ text_alignment,
-  card_link ? 'utc-card-2--card-link',
-  card_img_fill ? card_img_fill
-] | sort | join(' ') | trim %}
+{% if card_placeholder %}
+	{% set card_classes = [
+    'utc-card-2',
+    'h-100',
+    card_type ? 'utc-card-2--' ~ card_type,
+    card_color ? 'utc-card-2--none',
+    card_width ? 'utc-card-2--w-' ~ card_width,
+    text_alignment ? 'utc-card-2--align-' ~ text_alignment,
+    card_link ? 'utc-card-2--card-link',
+    card_img_fill ? card_img_fill
+  ] | sort | join(' ') | trim %}
+{% else %}
+	{% set card_classes = [
+    'utc-card-2',
+    'h-100',
+    card_type ? 'utc-card-2--' ~ card_type,
+    card_color ? 'utc-card-2--' ~ card_color : 'utc-card-2--white',
+    card_width ? 'utc-card-2--w-' ~ card_width,
+    text_alignment ? 'utc-card-2--align-' ~ text_alignment,
+    card_link ? 'utc-card-2--card-link',
+    card_img_fill ? card_img_fill
+  ] | sort | join(' ') | trim %}
+{% endif %}
+
 
 {# could use include statements for items like images and buttons in design system #}
   {% if card_link %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-card-base.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-card-base.html.twig
@@ -54,7 +54,7 @@
   ] | sort | join(' ') | trim %}
 {% endif %}
 
-
+{% if not card_placeholder %}
 {# could use include statements for items like images and buttons in design system #}
   {% if card_link %}
     <a href="{{ card_link }}" target="{{ card_link_target }}">
@@ -100,3 +100,9 @@
 	{% if card_link %}
      </a>
   {% endif %}
+
+{% else %}
+
+  <div class="{{ card_classes }}"></div>
+  
+{% endif %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-card.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-card.html.twig
@@ -40,7 +40,6 @@
     card_button_url: content.field_card_button.0['#url'],
 	card_button_target: content.field_card_button_target[0]|render == 'On' ? '_blank',
     card_link_target: content.field_card_link_target[0]|render == 'On' ? '_blank',
-    
     } %}
 
 	{% set item_card_2 = {
@@ -69,8 +68,7 @@
     card_button_text: content.field_card_button_3.0['#title'],
     card_button_url: content.field_card_button_3.0['#url'],
 	card_button_target: content.field_card_button_target_3[0]|render == 'On' ? '_blank',
-    card_link_target: content.field_card_link_target_3[0]|render == 'On' ? '_blank',
-      
+    card_link_target: content.field_card_link_target_3[0]|render == 'On' ? '_blank',    
     } %}
 
 	{# there may be a way to loop instead of using if statements 
@@ -82,8 +80,11 @@
 			just couldn't get it working #}
 
 
-		{% if card_count == 1 %}
-			<div class="utc-card-grid__container"> 
+	{% if card_count == 1 %}
+		{% set item_card_1 = {
+			card_placeholder: 'Off',
+		} %}
+		<div class="utc-card-grid__container"> 
 			{% set button_style_select = content["#block_content"].field_card_button_type.0.target_id %}
 			{% set button_style = drupal_field('field_css_class', 'taxonomy_term', button_style_select)["#object"].field_css_class.value %}
 			{% include 'block--utc-card-base.html.twig' with item_card_1 %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-card.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-card.html.twig
@@ -138,7 +138,7 @@
 				{% set button_style = drupal_field('field_css_class', 'taxonomy_term', button_style_select)["#object"].field_css_class.value %}
 				{% include 'block--utc-card-base.html.twig' with item_card_2 %}
 			</div>
-		{% if item_car3_1.card_placeholder %}
+		{% if item_card_3.card_placeholder %}
 			<div class="col-sm-12 col-lg-4 utc-card-grid__container utc-card-placeholder">
 		{% else %}
 			<div class="col-sm-12 col-lg-4 utc-card-grid__container">

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-card.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-card.html.twig
@@ -93,12 +93,21 @@
 	{% if card_count == 2 %}
 		{% set card_width = '100' %}
 		<div class="row utc-card-grid">
+			<div class="row utc-card-grid">
+		{% if item_card_1.card_placeholder %}
+			<div class="col-sm-12 col-lg-6 utc-card-grid__container utc-card-placeholder">
+		{% else %}
 			<div class="col-sm-12 col-lg-6 utc-card-grid__container">
+		{% endif %}
 				{% set button_style_select = content["#block_content"].field_card_button_type.0.target_id %}
 				{% set button_style = drupal_field('field_css_class', 'taxonomy_term', button_style_select)["#object"].field_css_class.value %}
 				{% include 'block--utc-card-base.html.twig' with item_card_1 %}
 			</div>
+		{% if item_card_2.card_placeholder %}
+			<div class="col-sm-12 col-lg-6 utc-card-grid__container utc-card-placeholder">
+		{% else %}
 			<div class="col-sm-12 col-lg-6 utc-card-grid__container">
+		{% endif %}
 				{% set button_style_select = content["#block_content"].field_card_button_type_2.0.target_id %}
 				{% set button_style = drupal_field('field_css_class', 'taxonomy_term', button_style_select)["#object"].field_css_class.value %}
 				{% include 'block--utc-card-base.html.twig' with item_card_2 %}
@@ -110,19 +119,30 @@
 		{% set card_width = '100' %}
 
 		<div class="row utc-card-grid">
+		{% if item_card_1.card_placeholder %}
+			<div class="col-sm-12 col-lg-4 utc-card-grid__container utc-card-placeholder">
+		{% else %}
 			<div class="col-sm-12 col-lg-4 utc-card-grid__container">
+		{% endif %}
 				{% set button_style_select = content["#block_content"].field_card_button_type.0.target_id %}
 				{% set button_style = drupal_field('field_css_class', 'taxonomy_term', button_style_select)["#object"].field_css_class.value %}
 				{% set card_link_target = card_link_target.0 == On ? '_blank' %}
 				{% include 'block--utc-card-base.html.twig' with item_card_1 %}
 			</div>
+		{% if item_card_2.card_placeholder %}
+			<div class="col-sm-12 col-lg-4 utc-card-grid__container utc-card-placeholder">
+		{% else %}
 			<div class="col-sm-12 col-lg-4 utc-card-grid__container">
+		{% endif %}
 				{% set button_style_select = content["#block_content"].field_card_button_type_2.0.target_id %}
 				{% set button_style = drupal_field('field_css_class', 'taxonomy_term', button_style_select)["#object"].field_css_class.value %}
 				{% include 'block--utc-card-base.html.twig' with item_card_2 %}
 			</div>
-
+		{% if item_car3_1.card_placeholder %}
+			<div class="col-sm-12 col-lg-4 utc-card-grid__container utc-card-placeholder">
+		{% else %}
 			<div class="col-sm-12 col-lg-4 utc-card-grid__container">
+		{% endif %}
 				{% set button_style_select = content["#block_content"].field_card_button_type_3.0.target_id %}
 				{% set button_style = drupal_field('field_css_class', 'taxonomy_term', button_style_select)["#object"].field_css_class.value %}
 				{% include 'block--utc-card-base.html.twig' with item_card_3 %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-card.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-card.html.twig
@@ -29,6 +29,7 @@
 
 	{# set variables for card content based on Drupal input #}
 	{% set item_card_1 = {
+	card_placeholder: content.field_card_1_placeholder[0]|render == 'On' ? 'Off',
     card_link: content.field_card_link.0['#url'],
     card_title: content.field_card_title|field_value,
     card_image: content.field_card_image|field_value,
@@ -43,6 +44,7 @@
     } %}
 
 	{% set item_card_2 = {
+	card_placeholder: content.field_card_2_placeholder[0]|render == 'On' ? 'Off',
     card_link: content.field_card_link_2.0['#url'],
     card_title: content.field_card_title_2|field_value,
     card_image: content.field_card_image_2|field_value,
@@ -57,6 +59,7 @@
     } %}
 
 	{% set item_card_3 = {
+	card_placeholder: content.field_card_3_placeholder[0]|render == 'On' ? 'Off',
     card_link: content.field_card_link_3.0['#url'],
     card_title: content.field_card_title_3|field_value,
     card_image: content.field_card_image_3|field_value,

--- a/source/default/_patterns/00-protons/legacy/css/components/card/_card.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/card/_card.css
@@ -16,6 +16,12 @@ in particle */
   }
 }
 
+@media (max-width: 640px) {
+  .utc-card-grid__container {
+    margin-bottom: 0px !important;
+  }
+}
+
 .utc-card-2 {
   position: relative;
   box-sizing: border-box;

--- a/source/default/_patterns/00-protons/legacy/css/components/card/_card.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/card/_card.css
@@ -17,7 +17,7 @@ in particle */
 }
 
 @media (max-width: 640px) {
-  .utc-card-grid__container {
+  .utc-card-placeholder {
     margin-bottom: 0px !important;
   }
 }


### PR DESCRIPTION
Add placeholder option for each card and if true, render the card with "none" class, meaning that particular card has no background and no shadows.

For example: If someone wants the size and position of cards to be in a three-card format, but they only provide content for one or two cards, the placeholder option preserves the  three-card format while "hiding" the unused card. 

NOTE: This will also hide any content the user may inadvertently add because it's a placeholder. If we don't add this part of the code, then any content provided will show without the background and shadows.

BEFORE (third card not hidden):

![Screen Shot 2021-08-25 at 8 26 17 AM](https://user-images.githubusercontent.com/82905787/130836440-5d31e8ca-ad8a-4558-b597-eb5c60de7805.png)

AFTER (third card hidden):

![Screen Shot 2021-08-25 at 1 14 53 PM](https://user-images.githubusercontent.com/82905787/130836457-16d1ae56-cd1e-49e3-aa0d-9d91ef35c4b5.png)

Here's is the CMS action:
(NOTE: The "Help" reads thus: "Check this if you have selected 3 cards in the "Number of Cards to Display" above and don’t want Card Three to show, but you need it as a placeholder to size and position the other cards in this series. This will hide any information you enter as well as any background and shadows from this card.")

![hide-3rd-card](https://user-images.githubusercontent.com/82905787/130841747-ad8bf08c-12ea-4ed5-8892-94b64671e40e.gif)

Also, had to remove the extra vertical space an empty card creates on the mobile. NOTE: This will be refactored to TailwindCSS when the rest of the card CSS is refactored.

![Screen Shot 2021-08-25 at 3 01 25 PM](https://user-images.githubusercontent.com/82905787/130850391-2f024150-ed17-44dd-8b77-53e1bda8210a.png)
