### PR TITLE
Fix missing card when 1 card is selected in UTC Cards

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--utc-card-base.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-card-base.html.twig
@@ -102,7 +102,7 @@
   {% endif %}
 
 {% else %}
-
-  <div class="{{ card_classes }}"></div>
-  
+  {% if not card_count == 1 %}  
+    <div class="{{ card_classes }}"></div>
+  {% endif %}
 {% endif %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-card-base.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-card-base.html.twig
@@ -102,7 +102,7 @@
   {% endif %}
 
 {% else %}
-  {% if not card_count == 1 %}  
-    <div class="{{ card_classes }}"></div>
-  {% endif %}
+
+  <div class="{{ card_classes }}"></div>
+  
 {% endif %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-card.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-card.html.twig
@@ -28,6 +28,20 @@
 	{% endif %}
 
 	{# set variables for card content based on Drupal input #}
+
+	{% set item_card_1_alone = {
+    card_link: content.field_card_link.0['#url'],
+    card_title: content.field_card_title|field_value,
+    card_image: content.field_card_image|field_value,
+    card_icon: content.field_card_icon|field_value,
+    card_icon_color: content.field_card_icon_color|field_value|render,
+    card_text: content.field_card_body|field_value,
+    card_button_text: content.field_card_button.0['#title'],
+    card_button_url: content.field_card_button.0['#url'],
+    card_button_target: content.field_card_button_target[0]|render == 'On' ? '_blank',
+    card_link_target: content.field_card_link_target[0]|render == 'On' ? '_blank',
+    } %}
+
 	{% set item_card_1 = {
 	card_placeholder: content.field_card_1_placeholder[0]|render == 'On' ? 'Off',
     card_link: content.field_card_link.0['#url'],
@@ -81,13 +95,10 @@
 
 
 	{% if card_count == 1 %}
-		{% set item_card_1 = {
-			card_placeholder: 'Off',
-		} %}
 		<div class="utc-card-grid__container"> 
 			{% set button_style_select = content["#block_content"].field_card_button_type.0.target_id %}
 			{% set button_style = drupal_field('field_css_class', 'taxonomy_term', button_style_select)["#object"].field_css_class.value %}
-			{% include 'block--utc-card-base.html.twig' with item_card_1 %}
+			{% include 'block--utc-card-base.html.twig' with item_card_1_alone %}
 		</div>
 	{% endif %}
 


### PR DESCRIPTION
**Show missing card when 1 card is selected in UTC Cards**.

Upon merge with dev, it was discovered that in a UTC card series where only one card was selected, that one card went missing. The issue is the code on lines 84-86 of block--utc-card-base.html.twig, where the item_card_1 placeholder variable was turned "off" if the card count was only 1.

PROBLEM:
On the Dev... There are two cards in the example below in two different UTC Card blocks with a selected "Number of Cards to Display" as "1". Both are missing: (You can see the actual page here: https://clouddev.utc.edu/library/special-collections)

![Screen Shot 2021-08-27 at 1 59 22 PM](https://user-images.githubusercontent.com/82905787/131171860-ccaa4f11-2cd7-489d-a468-dfd816d28d19.png)

The issue is the code on lines 84-86 of block--utc-card.html.twig, where the `item_card_1 `placeholder variable was turned "off" if the card count was only 1. The intent was nullify placeholder features when the card count was only 1. It ended up however, removing the content.

SOLUTION:
1. Remove that condition from the `card_count == 1` condition
2. Creating an new` {% set item_card_1_alone = {`... by duplicating `{% set item_card_1 = {`... and removing the placeholder variable
3. Calling  the `item_card_1_alone` variable  in the include of the `card_count == 1 `condition.
4. As a failsafe, but it may not be necessary, wrap `{% if not card_count == 1 %} ` condition around the empty div applied when "placeholder" is checked in block--utc-card-base.html.twig.

Now, when the card count is 1, it doesn't matter if the placeholder is checked or not. It will show whatever content the user enters:

_________________________________________________________________________

![Screen Shot 2021-08-27 at 2 10 59 PM](https://user-images.githubusercontent.com/82905787/131174042-205b3e2b-7ebf-4c99-9cfd-f0694b9dff87.png)

_________________________________________________________________________


![Screen Shot 2021-08-27 at 1 58 51 PM](https://user-images.githubusercontent.com/82905787/131174060-27283972-cd6e-4422-9250-dc53985b8ff1.png)

_________________________________________________________________________


**Card Count 2 with the second card as a placeholder:** 

![Screen Shot 2021-08-27 at 2 09 40 PM](https://user-images.githubusercontent.com/82905787/131174140-3caf536a-7b85-44d9-b3ae-b03b1d6cbe28.png)

_________________________________________________________________________


**Card Count 3 with the third card as a placeholder:** 

![Screen Shot 2021-08-27 at 2 10 15 PM](https://user-images.githubusercontent.com/82905787/131174168-af413186-fb07-4bac-a799-f45483f93aba.png)

_________________________________________________________________________


**Card Count 3, no placeholders:** 

![Screen Shot 2021-08-27 at 2 10 41 PM](https://user-images.githubusercontent.com/82905787/131174209-62a18430-e320-467e-a396-fa2ce2a2c364.png)

_________________________________________________________________________


**More screenshots with variations:**

![Screen Shot 2021-08-27 at 2 12 58 PM](https://user-images.githubusercontent.com/82905787/131174260-26a9096c-6588-484a-948d-8d034ed051ce.png)

_________________________________________________________________________


![Screen Shot 2021-08-27 at 2 13 19 PM](https://user-images.githubusercontent.com/82905787/131174272-5c023377-87ff-40aa-ab50-e1fdc0069c97.png)

_________________________________________________________________________


![Screen Shot 2021-08-27 at 2 13 54 PM](https://user-images.githubusercontent.com/82905787/131174276-f30b0025-b19d-4e09-be99-c897be503502.png)



