### PR TITLE
UTC-310: Avoids user from hiding all cards from a block at once

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--utc-card.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-card.html.twig
@@ -124,6 +124,9 @@
 				{% include 'block--utc-card-base.html.twig' with item_card_2 %}
 			</div>
 		</div>
+		{% if item_card_2.card_placeholder and item_card_1.card_placeholder %}
+		<h2 class="text-center"> Do not hide all the cards</h2>
+		{% endif %}
 	{% endif %}
 
 	{% if card_count == 3 %}
@@ -159,6 +162,9 @@
 				{% include 'block--utc-card-base.html.twig' with item_card_3 %}
 			</div>
 		</div>
+		{% if item_card_3.card_placeholder and item_card_2.card_placeholder and item_card_1.card_placeholder %}
+		<h2 class="text-center"> Do not hide all the cards </h2>
+		{% endif %}
 	{% endif %}
 
 {% endblock %}


### PR DESCRIPTION
checks whether all cards have been hidden and it warns the user about it.
<img width="1517" alt="Screen Shot 2021-08-28 at 10 09 47 PM" src="https://user-images.githubusercontent.com/39039024/131235898-b0eb36e0-5f84-4af9-94c5-8e8e5f845742.png">
<img width="1557" alt="Screen Shot 2021-08-28 at 10 10 07 PM" src="https://user-images.githubusercontent.com/39039024/131235903-4f803edf-baac-40aa-a4ea-e6bb37adcd20.png">
