### PR TITLE
Card count condition is not necessary

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--utc-card-base.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-card-base.html.twig
@@ -29,6 +29,9 @@
 #}
 
 {# could be the base card template in a design system #}
+{% if logged_in %}
+{{ attach_library('utccloud/utc-cards-placeholder') }}
+{% endif %}
 
 {% if card_placeholder %}
 	{% set card_classes = [
@@ -54,7 +57,9 @@
   ] | sort | join(' ') | trim %}
 {% endif %}
 
-{% if not card_placeholder %}
+{% if card_placeholder %}
+    <div class="{{ card_classes }}"></div>
+{% else %} 
 {# could use include statements for items like images and buttons in design system #}
   {% if card_link %}
     <a href="{{ card_link }}" target="{{ card_link_target }}">
@@ -101,8 +106,4 @@
      </a>
   {% endif %}
 
-{% else %}
-  {% if not card_count == 1 %}  
-    <div class="{{ card_classes }}"></div>
-  {% endif %}
 {% endif %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-card.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-card.html.twig
@@ -10,7 +10,7 @@
  * This template pulls in the variables to add to the cards. 
  * References the block--utc-card-base.html.twig to create the individual cards in this grid.
 #}
- 
+
 {% block content %}
 	{% set rendered_content = content|render %}
 	{# Sets variable to trigger content render array. #}

--- a/source/default/_patterns/00-protons/index.js
+++ b/source/default/_patterns/00-protons/index.js
@@ -47,6 +47,7 @@ import './legacy/css/pages/utc_error_pages.css';
 //Legacy JS
 import './legacy/js/utc-sidebar-menu.js';
 import './legacy/js/slick-custom-arrows.js';
+import './legacy/js/utc-card-placeholder.js';
 // import './legacy/js/ckeditor-jquery.js';
 
 // Export global variables.

--- a/source/default/_patterns/00-protons/legacy/js/utc-card-placeholder.js
+++ b/source/default/_patterns/00-protons/legacy/js/utc-card-placeholder.js
@@ -1,0 +1,64 @@
+(function($, Drupal, drupalSettings) {
+  "use strict";
+  //Prevents all cards from being a placeholder card at once.
+  Drupal.behaviors.cardsplaceholder = {
+    attach: function(context) {
+
+        $('select[data-drupal-selector="edit-settings-block-form-field-card-count"]' ).each(function(){
+            var cardCount = $(this).val();
+            
+            var cardOnePlaceholder = $('input[data-drupal-selector="edit-settings-block-form-field-card-1-placeholder-value"]');
+            var cardTwoPlaceholder = $('input[data-drupal-selector="edit-settings-block-form-field-card-2-placeholder-value"]');
+            var cardThreePlaceholder = $('input[data-drupal-selector="edit-settings-block-form-field-card-3-placeholder-value"]');
+
+            if (cardCount == 2) {
+                $(cardOnePlaceholder).change(function() {
+                    if ($(cardTwoPlaceholder).is(':checked')) {
+                        $(cardOnePlaceholder).prop( "checked", false );
+                        alert('You cannot hide all the cards.');
+                    }
+                });
+                $(cardTwoPlaceholder).change(function() {
+                    if ($(cardOnePlaceholder).is(':checked')) {
+                        $(cardTwoPlaceholder).prop( "checked", false );
+                        alert('You cannot hide all the cards.');
+                    }
+                });
+            }
+            if (cardCount == 3) {
+                $(cardOnePlaceholder).change(function() {
+                    if ($(cardTwoPlaceholder).is(':checked')) {
+                        if ($(cardThreePlaceholder).is(':checked')) {
+                            $(cardOnePlaceholder).prop( "checked", false );
+                            alert('You cannot hide all the cards.');
+                        }
+                    }
+                });
+                $(cardTwoPlaceholder).change(function() {
+                    if ($(cardOnePlaceholder).is(':checked')) {
+                        if ($(cardThreePlaceholder).is(':checked')) {
+                            $(cardTwoPlaceholder).prop( "checked", false );
+                            alert('You cannot hide all the cards.');
+                        }
+                    }
+                });
+                $(cardThreePlaceholder).change(function() {
+                    if ($(cardOnePlaceholder).is(':checked')) {
+                        if ($(cardTwoPlaceholder).is(':checked')) {
+                            $(cardThreePlaceholder).prop( "checked", false );
+                            alert('You cannot hide all the cards.');
+                        }
+                    }
+                });
+            }
+
+        });
+
+    }
+  };
+}(jQuery, Drupal, drupalSettings));
+
+
+
+
+    


### PR DESCRIPTION
Reorganize the placeholder condition and add placeholder js file.

Originally, new features on the UTC Cards caused single cards to go missing, but that was fixed with [PR #311](https://github.com/UTCWeb/particle/pull/311). When that PR was merged to dev, all single cards were showing, but the on https://clouddev.utc.edu/library, two library blocks (library events and library promo/feature) went missing. 

Library events missing on dev:
![Screen Shot 2021-08-30 at 2 09 37 PM](https://user-images.githubusercontent.com/82905787/131384787-35f20dd5-bc0b-4fff-8f20-258b4fba0d2c.png)

Library Promo Feature missing on dev:
![Screen Shot 2021-08-30 at 2 09 42 PM](https://user-images.githubusercontent.com/82905787/131386208-5dea6c5c-dca2-4354-95fc-65efc56d4932.png)


Upon investigation of the library blocks, it appears that those components don't use UTC Card templates. The "card" simulation is an override done in views:

![Screen Shot 2021-08-30 at 10 29 27 AM](https://user-images.githubusercontent.com/82905787/131385416-70eaa680-87b7-43b2-ad98-fb13065ede95.png)

So, upon merging this PR with dev again, we will need to check the library page again. It shows in the other three environments: local, test and production.

My local:
![Screen Shot 2021-08-30 at 2 16 44 PM](https://user-images.githubusercontent.com/82905787/131385639-1467a127-17af-4b5a-a7fc-e83c6bb24511.png)

![Screen Shot 2021-08-30 at 2 16 51 PM](https://user-images.githubusercontent.com/82905787/131385650-b4a44c32-032c-40b8-b491-4c2c46350f20.png)

Additionally and as an assist with [PR #312](https://github.com/UTCWeb/particle/pull/312), I have added library code and jquery.

![prevent-hiding-all-cards](https://user-images.githubusercontent.com/82905787/131386591-fa30db04-6168-420f-96ad-ff5e8b4af9b7.gif)




    

