### PR TITLE
UTC-179: Update twig template variable names.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--utc-highlights-block--default.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-highlights-block--default.html.twig
@@ -120,7 +120,7 @@
 							{{ utc_highlight.description_1 }}
 							</li>
 						{% endif %}
-						{% if utc_highlight.icon_2 %}
+						{% if utc_highlight.info_2 %}
 							<li class="{{ description_classes }}">
 							{% if utc_highlight.icon_2 %}
 							<div class="mb-4 {{ icon_color }}">{{ utc_highlight.icon_2 }}</div>
@@ -129,7 +129,7 @@
 							{{ utc_highlight.description_2 }}
 							</li>
 						{% endif %}
-						{% if utc_highlight.icon_3 %}
+						{% if utc_highlight.info_3 %}
 							<li class="{{ description_classes }}">
 							{% if utc_highlight.icon_3 %}
 							<div class="mb-4 {{ icon_color }}">{{ utc_highlight.icon_3 }}</div>
@@ -138,7 +138,7 @@
 							{{ utc_highlight.description_3 }}
 							</li>
 						{% endif %}
-						{% if utc_highlight.icon_4 %}
+						{% if utc_highlight.info_4 %}
 							<li class="{{ description_classes }}">
 							{% if utc_highlight.icon_4 %}
 							<div class="mb-4 {{ icon_color }}">{{ utc_highlight.icon_4 }}</div>


### PR DESCRIPTION
Simple naming error update to correct if statements in template. Should be based on info presence, not icon.