### PR TITLE
UTC-335: Change search text and button color.

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/global.css
+++ b/source/default/_patterns/00-protons/legacy/css/global.css
@@ -204,3 +204,11 @@ div.site-alert div.text {
         display: none !important;
     }
 }
+
+.block--search form input[type='submit'] {
+    @apply bg-utc-new-blue-500 border-utc-new-blue-500;
+}
+
+.block--search form input[type='submit']:hover {
+    @apply text-utc-new-gold-500;
+}


### PR DESCRIPTION
This is a request made by a high level designer involved with the Web Steering committee. Change the "Alert" red to regular blue and "Go Mocs" to more user-friendly and understood "Search". Note: The "Go Mocs!" is changed in the admin in the "Search form" selection on /admin/appearance/settings/particle. This will be updated after this PR is merged into develop.

**Before:**
![Screen Shot 2021-10-04 at 12 51 46 PM](https://user-images.githubusercontent.com/82905787/135891981-0065fe72-fc57-44ad-b2c5-040ee96d768c.png)


**After:**
![search](https://user-images.githubusercontent.com/82905787/135891164-fa4af843-9d5d-471f-a01d-bf20778ed51b.gif)

