### PR TITLE
350-UTCLib-Hours-View

### DIFF
--- a/apps/drupal-default/particle_theme/templates/views/views-view-unformatted--utc-library-item--hours_block.html.twig
+++ b/apps/drupal-default/particle_theme/templates/views/views-view-unformatted--utc-library-item--hours_block.html.twig
@@ -1,0 +1,51 @@
+{#
+/**
+ * @file
+ * Theme override to display a view of unformatted rows.
+ *
+ * Available variables:
+ * - title: The title of this group of rows. May be empty.
+ * - rows: A list of the view's row items.
+ *   - attributes: The row's HTML attributes.
+ *   - content: The row's content.
+ * - view: The view object.
+ * - default_row_class: A flag indicating whether default classes should be
+ *   used on rows.
+ *
+ * @see template_preprocess_views_view_unformatted()
+ */
+#}
+{# card_link: view.style_plugin.getField(key, 'field_utclib_item_link')|render|striptags, #}
+
+
+{% set card_classes = [
+  'utc-item-card',
+  'h-100',
+  card_link ? 'utc-item-card--card-link',
+] | sort | join(' ') | trim %}
+<div class="utc-item-card__view-two-col">
+  {% for key,row in rows %}
+    {% set content = {
+      card_mobile_stack: view.style_plugin.getField(key, 'field_utclib_mobile_stack'),
+      card_link: view.style_plugin.getField(key, 'field_utclib_item_link'),
+      card_image: view.style_plugin.getField(key, 'field_utclib_item_image'),
+      card_title: view.style_plugin.getField(key, 'field_utclib_item_title'),
+      card_text: view.style_plugin.getField(key, 'field_utclib_item_body')|raw,
+      card_badges: view.style_plugin.getField(key, 'field_utclib_item_badges')|raw,
+      card_add_info: view.style_plugin.getField(key, 'field_utclib_item_add_info'),
+      card_divider: view.style_plugin.getField(key, 'field_utclib_item_divider')|render|striptags|clean_class,
+    } %}
+
+    <div class="utc-card-grid__container">
+        <div class="utc-card-2 utc-card-2--thumbnail utc-card-2--w-100 utc-card-2--white">
+          <div class="utc-card-2__body">
+            <h3 class="utc-card-2__title">{{ content.card_title }}</h3>
+            <div class="utc-card-2__text">
+              <p>{{ content.card_text }}</p>
+            </div>
+          </div>
+        </div>
+    </div>
+
+  {% endfor %}
+</div>


### PR DESCRIPTION
Created a twig file for this view. Puts content in appropriate place and removes some unnecessary SCSS classes from the parent utc-library-item twig file. 