### PR TITLE
UTC-1918: Isolate breadcrumb adjustments to certain utc content types…

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/components/navigation/_breadcrumb.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/navigation/_breadcrumb.css
@@ -29,7 +29,10 @@
 .simple-breadcrumb li:last-child:after {
 	display: none;
 }
-.block--system-breadcrumb-block {
+.page-node-type-utc-academic-homepage .block--system-breadcrumb-block,
+.page-node-type-utc-academic-internal-page .block--system-breadcrumb-block,
+.page-node-type-utc-admin-homepage .block--system-breadcrumb-block,
+.page-node-type-utc-admin-internal-page .block--system-breadcrumb-block {
     margin-top: -2rem;
 }
 @media (max-width: 768px) {


### PR DESCRIPTION
Applied the breadcrumb fix from Particle PR [344](https://github.com/UTCWeb/particle/pull/344), to only certain content types to cure breakage on generic pages such as Search, user, category, tags, etc.

### **Content types applied:**

- UTC Academic Homepage (not necessarily needed, but preventative)
- UTC Academic Internal Page
- UTC Admin Homepage (not necessarily needed, but preventative)
- UTC Admin Internal Page.

### **Results:** 

**Content types applied:**


**Academic Internal page:**

![Screen Shot 2021-11-01 at 4 44 07 PM](https://user-images.githubusercontent.com/82905787/139741282-19fbecb4-a8d9-4497-a763-4ef427f2114e.png)



**Admin Internal page:**

![Screen Shot 2021-11-01 at 4 43 55 PM](https://user-images.githubusercontent.com/82905787/139741277-35dc65cc-8205-4dad-a83f-37f18b537f43.png)



**Other pages not applied:**

**Search:**
![Screen Shot 2021-11-01 at 4 56 15 PM](https://user-images.githubusercontent.com/82905787/139741180-99143e74-eb8b-4917-a007-084fb3c2933b.png)



**Media:**
![Screen Shot 2021-11-01 at 4 56 01 PM](https://user-images.githubusercontent.com/82905787/139741194-92de1813-9f03-4f8f-b5de-a0f46604f1dd.png)



**Tags:**
![Screen Shot 2021-11-01 at 4 55 30 PM](https://user-images.githubusercontent.com/82905787/139741199-4d17cfc0-8bba-43b7-a989-40e5be3fe855.png)

