### PR TITLE
UTC-367: Fix the missing headline in the image hover component.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hover-images.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hover-images.html.twig
@@ -10,6 +10,7 @@
  *This template is the sole custom template for this component. It uses Custom Block with Paragraph integration. Vertical and horizontal detection are built in through Media Type > Image > UTC Hover Images.
 #}
 
+
 {% block content %}
     {# block fields #}
     {% set hover_image_orientation = content.field_image_orientation|field_value|render %}
@@ -22,7 +23,7 @@
     {% for item in content.field_hover_image_block['#items'] %}
 
         {# paragraph fields #}  
-        {% set paragraph_title = item.entity.field_hover_title_30.value %}
+        {% set paragraph_title = item.entity.field_hover_title.value %}
         {% set paragraph_text = item.entity.field_hover_text.value %}
         {% set paragraph_media_id = item.entity.field_hover_image.target_id %}
         {% set paragraph_url = item.entity.field_hover_link.0.url %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hover-images.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hover-images.html.twig
@@ -10,7 +10,6 @@
  *This template is the sole custom template for this component. It uses Custom Block with Paragraph integration. Vertical and horizontal detection are built in through Media Type > Image > UTC Hover Images.
 #}
 
-
 {% block content %}
     {# block fields #}
     {% set hover_image_orientation = content.field_image_orientation|field_value|render %}


### PR DESCRIPTION
Upon deployment the headline went missing in the image hover component. I think what happened was when the change from `image_hover_title_30` was changed to `image_hover_title` (the last edit), the file with the older field name got picked up. This committed file shows the correct (and matches the development config) call to the `image_hover_title`.

Development (incorrect):

![Screen Shot 2021-11-29 at 1 13 50 PM](https://user-images.githubusercontent.com/82905787/143921587-5823e11d-a920-456f-ab0e-d233879c10b1.png)

Local (correct):

![Screen Shot 2021-11-29 at 1 14 03 PM](https://user-images.githubusercontent.com/82905787/143921642-c3fab59a-6874-4729-bccf-4544ff8d6e9b.png)


