### PR TITLE
385-UTCLib fixes error in twig file

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--library-hours-block.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--library-hours-block.html.twig
@@ -26,7 +26,9 @@
  */
 #}
 
-<div{{ attributes }}>
+{% extends "block.html.twig" %}
+
+{% block content %}
   <div class="utc-card-grid__container">
     <div class="utc-card-2 utc-card-2--thumbnail utc-card-2--w-100 utc-card-2--white">
       <div class="utc-card-2__body">
@@ -54,11 +56,11 @@
           </tr>
           <tr>
             <td style="width: 50%"><strong>24/5</strong></td>
-            <td style="width: 50%"><strong>{{ content['#items'][6] }}</strong></td>
+            <td style="width: 50%"><strong>{{ content['#items'][5] }}</strong></td>
           </tr>
           </tbody>
         </table>
       </div>
     </div>
   </div>
-</div>
+{% endblock %}


### PR DESCRIPTION
# Pull Request

Closes Issue #385 


## Issue Description

<!--
Twig file needed to extended the base block.html.twig file and not just include the attributes in the container div
-->

## Summary of Changes

<!--
Extended the base twig file, which fixed the issue. 
-->
