### PR TITLE
UTC-427: Remove &nbsp; from blockquotes.

### DIFF
--- a/source/default/_patterns/00-protons/index.js
+++ b/source/default/_patterns/00-protons/index.js
@@ -48,6 +48,7 @@ import './legacy/css/components/UTC-custom-blocks/_utc_hover_images.css';
 //Legacy JS
 import './legacy/js/utc-sidebar-menu.js';
 import './legacy/js/slick-custom-arrows.js';
+import './legacy/js/utc-quoteblock.js';
 // import './legacy/js/ckeditor-jquery.js';
 
 // Export global variables.

--- a/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_blockquotes.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_blockquotes.css
@@ -1,11 +1,11 @@
 blockquote {
-    @apply w-full my-8 mx-auto italic py-4 bg-gray-250 border-0;
+    @apply w-full my-8 mx-auto italic pt-4 pb-10 bg-gray-250 border-0 pr-8;
 }
 blockquote:before {
     @apply hidden
 }
 blockquote p {
-    @apply pl-16 relative text-center my-0 mx-auto text-xl -mt-4 mb-4;
+    @apply pl-16 relative text-center my-0 mx-auto text-xl mt-8 mb-0;
     border-left: 12px solid #C4CBD4;
     width: fit-content;
     max-width:90%;
@@ -18,15 +18,15 @@ blockquote p:before {
     content: '\201C';
 }
 blockquote p:after {
-    @apply text-8xl -ml-1 absolute font-utcquote text-utc-new-blue-200;
+    @apply text-8xl ml-1 absolute font-utcquote text-utc-new-blue-200;
     content: "\201D";
 }
 /***for styles dropdown in the text-editor***/
 p.quote-credit {
-    @apply -mt-11 text-center bg-utc-bg-quoteblock pl-8 pb-12 text-base;
+    @apply -mt-14 text-center bg-utc-bg-quoteblock pl-8 pb-8 text-base;
 }
 blockquote p.quote-credit {
-    @apply mt-5 border-0 not-italic pb-4 pl-16;
+    @apply mt-5 border-0 not-italic pb-0 pl-16 -mb-2;
 }
 p.quote-credit:before, 
 p.quote-credit:after {
@@ -34,5 +34,8 @@ p.quote-credit:after {
     content: "\2014";
     left: unset;
     top: unset;
+}
+blockquote p.quote-credit:before {
+    @apply mr-1;
 }
 

--- a/source/default/_patterns/00-protons/legacy/js/utc-quoteblock.js
+++ b/source/default/_patterns/00-protons/legacy/js/utc-quoteblock.js
@@ -1,0 +1,16 @@
+
+
+(function($, Drupal, drupalSettings) {
+    "use strict";
+    Drupal.behaviors.blockquote = {
+        attach: function(context, settings) {
+            /***Remove any "&nbsp;" from blockquotes bc this interferes with formatting */
+            $('blockquote').each(function(){
+                var blockQuote = $(this).html();
+                blockQuote = blockQuote.replace(/&nbsp;/g, ' ');
+                $(this).html(blockQuote);
+            });
+        }
+    };
+}(jQuery, Drupal, drupalSettings));
+  


### PR DESCRIPTION
Upon discovering that   is injected by the CMS into some blockquotes and some not, the formatting of blockquotes cannot be consistently applied.

Created a js function that removes from blockquotes so css can be consistently applied and made appropriate css adjustments for a variety of blockquote applications.

Before:
![Screen Shot 2022-04-01 at 9 47 27 AM](https://user-images.githubusercontent.com/82905787/161282687-11678f1f-1b4c-426b-9543-8c40d2310b25.png)

After:
![Screen Shot 2022-04-01 at 9 47 37 AM](https://user-images.githubusercontent.com/82905787/161282715-86844a1a-e362-4ddb-9e15-4af7df5ce966.png)

