### PR TITLE
UTC-429: Footer icons (all links) gold on hover.

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/footer.css
+++ b/source/default/_patterns/00-protons/legacy/css/footer.css
@@ -13,8 +13,11 @@
 }
 .footer-wrapper a{
   @apply text-white;
+  transition: var(--utc-transition);
 }
-
+.footer-wrapper a:hover{
+  @apply text-utc-new-gold-500;
+}
 .footer-bottom-wrapper {
   @apply bg-utc-new-blue-800 text-white;
 


### PR DESCRIPTION
Footer icons and links are gold on hover with a transition applied.

![Screen Shot 2022-04-04 at 11 31 16 AM](https://user-images.githubusercontent.com/82905787/161579011-6e9c5907-ef1f-44ca-bd21-e5d00322d7ea.png)
