### PR TITLE
UTC-431: Force overrides of mobile menu.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/off-canvas/region--offcanvas-sidebar.html.twig
+++ b/apps/drupal-default/particle_theme/templates/off-canvas/region--offcanvas-sidebar.html.twig
@@ -24,7 +24,7 @@
 
 {% if content %}
   <div{{ attributes.addClass(classes) }}>
-    <div id="offcanvas-sidebar" class="sidr z-10 h-full mb-0 bg-transparent shadow-none fixed" style="display: none;">
+    <div id="offcanvas-sidebar" class="sidr z-10 h-full mb-0 bg-transparent shadow-none" style="display: none;">
       <div class="menus-wrapper w-full overflow-y-scroll overflow-x-hidden">
         {{ content }}
       </div>

--- a/source/default/_patterns/00-protons/legacy/css/components/header/_utc_custom_header.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/header/_utc_custom_header.css
@@ -222,15 +222,20 @@ ul.sf-menu span.sf-sub-indicator {
 #block-utcsecondarymenu-offcanvas .sf-accordion-toggle{
     @apply hidden;
 }
-/***Undo .sf-hidden classes on ul and force mobile menus to be always open***/
+.sidr ul.sf-menu span.sf-depth-1.sf-with-ul.sf-clicked {
+    background: #e7eaee;
+}
+/***Undo .sf-hidden classes on ul and force mobile menus (top level) to be always open***/
 .sidr ul.sf-menu.menu.sf-secondary-menu.sf-hidden, 
 .sidr ul.sf-menu.menu.sf-hidden {
-    background: #e7eaee!important;
     left: auto !important;
     position: relative!important;
     top: auto !important;
-    display:block!important;
+    display:flex!important;
+    flex-direction:column;
     height:auto!important;
+    background: #e7eaee!important;
+    padding-left:1rem;
 }
 
 /*****end offcanvas responsive menu****/
@@ -401,6 +406,22 @@ div.site-alert div.text {
     .sidr {
         top: 62px;
     }
+
+    /***Undo site alerts issues with fixed position of mobile menu.****/
+    .notification-alert-on .sidr {
+        @apply opacity-0;
+        transition: right .4s, opacity .2s!important;
+    }
+    .notification-alert-on.offcanvas-sidebar-open .sidr {
+        @apply relative top-0 opacity-100;
+    }
+    /*Since the menu is now scrollable with an alert, let's show the site.*/
+    .notification-alert-on .offcanvas-sidebar-overlay {
+        background:transparent!important;
+        opacity:100%!important;
+    }
+    /***end special alert implementation***/
+
     .top-bar-wrapper,.header--custom-header .header__container-wrapper--header__main {
          height:unset;
      }


### PR DESCRIPTION
This PR addresses a couple of issues with the mobile menu.

1. **The DOM issues still persisted from this issue:** https://github.com/UTCWeb/particle/issues/410
CSS updates force the mobile menu to behave correctly.

Before:
![mobile-menu-issues](https://user-images.githubusercontent.com/82905787/161566476-99b726fe-719f-4513-b36c-27543f557cbc.gif)

After: 
![correct-mobile](https://user-images.githubusercontent.com/82905787/161812431-abc41615-2b0a-4cc7-8745-8cda914fc344.gif)

2. **Site Alert issues:** When a site alert is present with mobile menu, the "fixed" position doesn't look right. This CSS (and twig adjustment) makes the menu "relative" only when there is a site alert, which applies a body class of "notification-alert-on" via the brandbar.js. The background is no longer "ghosted" out since the menu is now scrollable and the site can be seen. 

Before: 
![Screen Shot 2022-04-05 at 11 57 17 AM](https://user-images.githubusercontent.com/82905787/161813003-55462418-53c9-48f0-9973-2303b6174a08.png)


After:
![mobile-menu-alert](https://user-images.githubusercontent.com/82905787/161813064-22417ce3-5597-408f-bdf1-d5a6965951d3.gif)





