### PR TITLE
UTC-435: Fix obscured header when logged in.

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/components/header/_utc_custom_header.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/header/_utc_custom_header.css
@@ -377,6 +377,10 @@ a.close-search-btn, a.close-search-btn:hover, a.close-search-btn:active {border:
     right:0;
     width:100%;
 }
+.user-logged-in .header-container {
+    position: relative;
+    top:unset;
+}
 .header-container a, .header-container a:hover, .header-container a:active {
     @apply no-underline
 }
@@ -393,11 +397,33 @@ div.site-alert div.text {
     .header__container--boxed {
         @apply max-w-full;
     }
+    .user-logged-in .header-container {
+        margin-top:36px;
+    }
 }
+/* ipad Mini */
+/*@media only screen 
+  and (min-device-width: 768px) 
+  and (max-device-width: 1024px) 
+  and (-webkit-min-device-pixel-ratio: 1) {
+    .user-logged-in .header-container {
+        margin-top:0;
+    }
+}
+/* ipad Air */
+/*@media only screen 
+  and (min-device-width: 768px) 
+  and (max-device-width: 1024px) 
+  and (-webkit-min-device-pixel-ratio: 2){
+    .user-logged-in .header-container {
+        margin-top:36px;
+    }
+}*/
 @media screen and (max-width: 768px) {
     .header--custom-header .header__main {
         @apply mr-28;
     }
+
     .sidr {
         top: 62px;
     }

--- a/source/default/_patterns/00-protons/legacy/css/global.css
+++ b/source/default/_patterns/00-protons/legacy/css/global.css
@@ -2,9 +2,11 @@
 :root {
   --utc-transition: all 0.4s ease-in-out;
   --utc-color: color 0.4s ease-in-out;
-  --utc-link: color 0.4s ease-in-out, font-weight 0.4s ease-in-out;
+  --utc-link: color 0.4s ease-in-out;
 }
-
+html {
+  scroll-behavior: smooth;
+}
 .gsc-results .gsc-cursor-box .gsc-cursor-page {
   color: #000000 !important;
   background-color: #fff !important;
@@ -265,24 +267,14 @@ a.focus-visible, a:focus-visible {
 }
 .utc-card-2__text a:not(.btn):not(.ckeditor-accordion-toggler),
 .utc-sidebar-card a:not(.btn):not(.ckeditor-accordion-toggler),
-.utc-item-card a:not(.btn):not(.ckeditor-accordion-toggler),
-.UTCtextblock__links
-  a:not(.btn):not(.dm-profile-tabs__link):not(.ckeditor-accordion-toggler) {
-  @apply text-utc-links-static font-normal no-underline;
-  transition: var(--utc-link);
-}
-.utc-card-2__text a:not(.btn):not(.ckeditor-accordion-toggler),
-.utc-sidebar-card a:not(.btn):not(.ckeditor-accordion-toggler),
-.utc-item-card a:not(.btn):not(.ckeditor-accordion-toggler),
-.UTCtextblock__links a:not(.btn):not(.dm-profile-tabs__link):not(.ckeditor-accordion-toggler) {
-  @apply border-b border-utc-links-static no-underline;
+.utc-item-card a:not(.btn):not(.ckeditor-accordion-toggler) {
+  @apply text-utc-links-static font-normal border-0 no-underline;
   transition: var(--utc-link);
 }
 .utc-card-2__text a:not(.btn):not(.ckeditor-accordion-toggler):hover,
 .utc-sidebar-card a:not(.btn):not(.ckeditor-accordion-toggler):hover,
-.utc-item-card a:not(.btn):not(.ckeditor-accordion-toggler):hover,
-.UTCtextblock__links a:not(.btn):not(.dm-profile-tabs__link):hover:not(.ckeditor-accordion-toggler):hover {
-  @apply text-utc-new-blue-800 border-0 font-medium no-underline;
+.utc-item-card a:not(.btn):not(.ckeditor-accordion-toggler):hover {
+  @apply text-utc-new-blue-800 font-medium;
 }
 a:active,
 .utc-card-2__text a:not(.btn):not(.ckeditor-accordion-toggler):active,


### PR DESCRIPTION
This PR is regarding https://github.com/UTCWeb/particle/issues/435.
This is solved on most devices. However, iPad mini, Nest Hub and Surface Duo show a gap at the top. Targeting these devices is a bit more tricky. For example, if it's fixed for iPad mini, then iPad air will be off. It has to do with the size of the admin header.

iPad Air:
![Screen Shot 2022-04-08 at 4 55 31 PM](https://user-images.githubusercontent.com/82905787/162528909-08037137-9360-41b7-9266-974d67177374.png)


iPad Mini:
![Screen Shot 2022-04-08 at 4 55 39 PM](https://user-images.githubusercontent.com/82905787/162528869-75928f06-3b62-4c67-adc6-348b8c18fb8d.png)


iPhone 12 Pro:
![Screen Shot 2022-04-08 at 4 55 50 PM](https://user-images.githubusercontent.com/82905787/162528876-25afab25-fb93-4e19-a326-303f47fbe569.png)

