### PR TITLE
UTC-438: Make digital measures text white on bg.

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/digital_measures/tabbed.css
+++ b/source/default/_patterns/00-protons/legacy/css/digital_measures/tabbed.css
@@ -31,6 +31,10 @@
 	color: rgb(255, 255, 255);
 }
 
+.dm-profile-preamble li.dm-profile-activity {
+	color: rgb(255, 255, 255);
+}
+
 .dm-profile-preamble .dm-profile-content .dm-profile-activities {
 	text-align: left;
 }


### PR DESCRIPTION
UTC-438: Fix CSS to make digital measures text white on bg.

BAD:
![Screen Shot 2022-04-12 at 3 06 44 PM](https://user-images.githubusercontent.com/82905787/163040384-2a668f39-549b-4131-93bb-43f78fd1198d.png)

GOOD:
![Screen Shot 2022-04-12 at 3 37 33 PM](https://user-images.githubusercontent.com/82905787/163040351-6c9cbb1c-785e-4c4f-bbc9-bcaffa334b27.png)