### PR TITLE
Hotfix/utc 441 fix wrap on wide cards

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/components/card/_card.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/card/_card.css
@@ -211,7 +211,6 @@ a .utc-card-2--white.utc-card-2--card-link:hover p {
 
   .utc-card-2--wide .utc-card-2__body {
     flex: 1 0 65%;
-    max-width: 100%;
   }
 
   .utc-card-2--wide .utc-card-2__icon {

--- a/source/default/_patterns/00-protons/legacy/css/components/card/_card.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/card/_card.css
@@ -200,6 +200,10 @@ a .utc-card-2--white.utc-card-2--card-link:hover p {
 
 /* ========== Wide Card ========= */
 
+.utc-card-2--wide .utc-card-2__body {
+  max-width: 100%;
+}
+
 @media (min-width: 576px) {
   .utc-card-2--wide {
     flex-direction: row;

--- a/source/default/_patterns/00-protons/legacy/css/components/card/_card.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/card/_card.css
@@ -207,6 +207,7 @@ a .utc-card-2--white.utc-card-2--card-link:hover p {
 
   .utc-card-2--wide .utc-card-2__body {
     flex: 1 0 65%;
+    max-width: 100%;
   }
 
   .utc-card-2--wide .utc-card-2__icon {


### PR DESCRIPTION
Solution to issue #441 .

Add `max-width: 100% ` to wide cards regardless of screen size.

Before: 
![Screen Shot 2022-04-14 at 11 11 41 AM](https://user-images.githubusercontent.com/82905787/163421124-93986265-8b27-4e45-b6d3-4d8be6e61287.png)

After:
![Screen Shot 2022-04-14 at 11 21 13 AM](https://user-images.githubusercontent.com/82905787/163424291-04e8876a-4999-4cb3-9ca2-59e3d4d4ddfd.png)

![Screen Shot 2022-04-14 at 11 33 11 AM](https://user-images.githubusercontent.com/82905787/163424310-eec8a7f4-66a5-4847-a39c-40b6a8515e33.png)

![Screen Shot 2022-04-14 at 11 33 21 AM](https://user-images.githubusercontent.com/82905787/163424325-d7bdc507-c48c-4a41-9253-5cbebe36bb95.png)

