### PR TITLE
UTC-443: Fix FA icon color 4th card.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--utc-card.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-card.html.twig
@@ -88,7 +88,7 @@
     card_title: content.field_card_title_4|field_value,
     card_image: content.field_card_image_4|field_value,
     card_icon: content.field_card_icon_4|field_value,
-    card_icon_color: content.field_card_icon_color_3|field_value|render,
+    card_icon_color: content.field_card_icon_color_4|field_value|render,
     card_text: content.field_card_body_4|field_value,
     card_button_text: content.field_card_button_4.0['#title'],
     card_button_url: content.field_card_button_4.0['#url'],

--- a/source/default/_patterns/00-protons/legacy/css/components/card/_card.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/card/_card.css
@@ -174,6 +174,11 @@ a .utc-card-2--white.utc-card-2--card-link:hover p {
   transition: var(--utc-transition);
 }
 
+.utc-card-2__icon--white .fontawesome-icons {
+  @apply text-white;
+  transition: var(--utc-transition);
+}
+
 .utc-card-2__icon .utc-card-2:hover {
   @apply text-utc-new-blue-500;
 


### PR DESCRIPTION
This pull request fixes #1 of issue [#443](https://github.com/UTCWeb/particle/issues/443). The error was in the twig file where the font icon color was calling card three's icon color variable, not card four.

BEFORE:
![Screen Shot 2022-04-14 at 2 20 21 PM](https://user-images.githubusercontent.com/82905787/163458608-2574436b-7991-4090-aa8b-3a05b1c0145d.png)

AFTER:
![Screen Shot 2022-04-14 at 2 56 11 PM](https://user-images.githubusercontent.com/82905787/163458637-9fe65cb0-8ea7-4b49-903e-5ec23c46c128.png)


