### PR TITLE
UTC-445: Add colored hz rules for colored bgs.

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/global.css
+++ b/source/default/_patterns/00-protons/legacy/css/global.css
@@ -355,7 +355,18 @@ h3.blue-bar {
 h3.gold-bar {
   @apply bg-utc-new-gold-500 p-3 m-0 mb-6 text-utc-new-blue-500 w-full;
 }
-
+.white-hz-rule {
+  @apply bg-white w-full;
+  height:1px;
+}
+.gold-hz-rule {
+  @apply bg-utc-new-gold-500 w-full;
+  height:1px;
+}
+.blue-hz-rule {
+  @apply bg-utc-new-blue-500 w-full;
+  height:1px;
+}
   /****hide extra arrow on iphones***/
   .sidr ul.sf-menu span.sf-sub-indicator {
     content: "▼";


### PR DESCRIPTION
This adds gold, blue, and white horizontal lines options in the style dropdown in text editor to be used for various different colored backgrounds.

![Screen Shot 2022-04-14 at 3 52 50 PM](https://user-images.githubusercontent.com/82905787/163466527-760e715c-6822-43a9-a5bd-68a89f78f8ff.png)

