### PR TITLE
UTC-447: Remove ol,ul,li text color from global.

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/global.css
+++ b/source/default/_patterns/00-protons/legacy/css/global.css
@@ -248,9 +248,6 @@ body {
   /**in order to implement sticky on the header_container, we must unset the overflows on its ancestor***/
   overflow: unset;
 }
-ol, ul, li {
-  @apply text-utc-new-blue-500;
-}
 @keyframes fadeIn {
   0% {opacity:0;}
   100% {opacity:1;}


### PR DESCRIPTION
UTC-447: Remove ol,ul,li text color from global.css