### PR TITLE
UTC-449: Fix footer FA icons.

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/footer.css
+++ b/source/default/_patterns/00-protons/legacy/css/footer.css
@@ -15,6 +15,16 @@
   @apply text-white;
   transition: var(--utc-transition);
 }
+
+/*Force footer icons to override latent css load of FA PRO v6 defaults*/
+#block-socialmedialinks .social-media-links--platforms.horizontal li {
+  padding: 0.75em 0.35em 0.2em!important;
+}
+#block-socialmedialinks .social-media-links--platforms a {
+  font-size: .5rem!important;
+}
+/***end force***/
+
 .footer-wrapper a:hover{
   @apply text-utc-new-gold-500;
 }


### PR DESCRIPTION
This PR overrides the the new FA Pro latent load of css in the footer via js. 

Before:
![Screen Shot 2022-04-19 at 4 27 32 PM](https://user-images.githubusercontent.com/82905787/164094571-cd835490-fdd3-4aa0-967c-861366da6044.png)

After:
![Screen Shot 2022-04-19 at 4 58 57 PM](https://user-images.githubusercontent.com/82905787/164094636-b21558d5-f8b3-405f-a9a1-dc9b9e9aee6f.png)

