### PR TITLE
Hotfix/utc 451 fix ipad mini mobile menu

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/components/header/_utc_custom_header.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/header/_utc_custom_header.css
@@ -208,7 +208,7 @@ ul.sf-menu span.sf-sub-indicator {
     padding-bottom:60px;
 }
 .menus-wrapper ul, #superfish-secondary-menu--2-accordion {
-    width:12.8rem;
+    width:12.8rem!important;
     float:right;
     box-shadow: -3px 3px 5px rgb(0 0 0/15%)!important;
 }
@@ -297,7 +297,7 @@ a.close-search-btn, a.close-search-btn:hover, a.close-search-btn:active {border:
 }
 .js-toggle-offcanvas-sidebar .fas:before {
     /***fontawesome fa-bars content***/
-    content: "\f0c9";  
+    /*content: "\f0c9"; */ 
     transition: var(--utc-transition); 
     outline:none!important;
 }
@@ -306,7 +306,7 @@ a.close-search-btn, a.close-search-btn:hover, a.close-search-btn:active {border:
 }
 .sidr-open .js-toggle-offcanvas-sidebar .fas:before {
     /***fontawesome fa-times content***/
-    content: "\f00d";
+    /*content: "\f00d";*/
 }
 /****end responsive menu icon****/
 
@@ -432,7 +432,10 @@ div.site-alert div.text {
     .sidr {
         top: 62px;
     }
-
+    .menus-wrapper ul, #superfish-secondary-menu--2-accordion {
+        /*allow for left shadow to show*/
+        width:12.8rem!important;
+    }
     /***Undo site alerts issues with fixed position of mobile menu.****/
     .notification-alert-on .sidr {
         @apply opacity-0;
@@ -504,10 +507,7 @@ div.site-alert div.text {
     .sidr.right {
         width:13rem!important;
     }
-    .menus-wrapper ul, #superfish-secondary-menu--2-accordion {
-        /*allow for left shadow to show*/
-        width:12.8rem!important;
-    }
+    
     .sidr ul.sf-menu.sf-accordion li.sf-expanded:last-child>ul {
         @apply mb-16;
     }

--- a/source/default/_patterns/00-protons/legacy/css/components/header/_utc_custom_header.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/header/_utc_custom_header.css
@@ -434,7 +434,11 @@ div.site-alert div.text {
     }
     .menus-wrapper ul, #superfish-secondary-menu--2-accordion {
         /*allow for left shadow to show*/
-        width:12.8rem!important;
+        width:12.9rem!important;
+    }
+    #superfish-secondary-menu--2-accordion {
+        margin-right: -1px!important;
+        margin-top: -3px;
     }
     /***Undo site alerts issues with fixed position of mobile menu.****/
     .notification-alert-on .sidr {
@@ -470,9 +474,7 @@ div.site-alert div.text {
     .d-flex { 
         @apply border-r border-gray-500 pr-8;
     }
-    #superfish-secondary-menu--2-accordion {
-        margin-right: -1px!important;
-    }
+
     .sidr ul.sf-menu.sf-accordion li.sf-expanded:last-child>ul >li:last-child {
         @apply mb-4;
     }


### PR DESCRIPTION
The width for the iPad Mini secondary menu ("I am..." and "Quick Links") is not applying the width set in css. The width default is "1px". This needs an !important.

Also, FA css icons have been removed in favor of the SVG js icons applied by FA Pro v6.

Before:
![Screen Shot 2022-04-25 at 8 35 11 AM](https://user-images.githubusercontent.com/82905787/165090733-9f8a8133-008e-4144-979d-ab28d60c8175.png)


After:
![Screen Shot 2022-04-25 at 8 41 04 AM](https://user-images.githubusercontent.com/82905787/165090961-4a07ae5b-12cf-462a-8d80-718656a11379.png)


