### PR TITLE
UTC-452: Fix non-rotating plus and update sidebar with better UX/UI.

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
+++ b/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
@@ -55,7 +55,6 @@
 }
 .utc-sidebar .sidebar-menu .open > .more i, .utc-sidebar .sidebar-menu .open > .more svg {
   transform: rotate(90deg);
-  top: 6px;
   position: absolute;
 }
 .utc-sidebar .more{

--- a/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
+++ b/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
@@ -70,7 +70,7 @@ li.menu-item-sidemenu li.menu-item-sidemenu  .is-active {
 }
 li.menu-item-sidemenu li.menu-item-sidemenu  .is-active:before {
   @apply mr-2 font-bold text-2xl;
-  content: "›";
+  content: "→";
 }
 
 @media (min-width: 991px) {

--- a/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
+++ b/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
@@ -27,17 +27,19 @@
   transition: all 0.3s ease;
 }
 .utc-sidebar .sidebar-menu li ul .menu-item-sidemenu a {
-  @apply bg-gray-300;
+  @apply bg-utc-new-blue-100;
 }
 .utc-sidebar .sidebar-menu li ul .menu-item-sidemenu a:hover {
-  @apply bg-gray-800;
-  @apply text-white;
+  @apply bg-utc-new-blue-200 text-utc-new-blue-500;
   /* color: white;
   background-color: darkgray; */
 }
+.utc-sidebar .menu-item-sidemenu.open > a {
+  @apply bg-utc-new-blue-500 text-white
+}
 .utc-sidebar .menu-btn {
   /* background: lightblue; */
-  @apply bg-blue-100;
+  @apply bg-utc-new-blue-100;
   text-align: center;
   cursor: s-resize;
 }
@@ -48,14 +50,23 @@
 .utc-sidebar .menu-open, .utc-sidebar .sidebar-menu .open > ul {
   max-height: 2000px;
 }
-.utc-sidebar .sidebar-menu .open > .more i {
-  transform: rotate(-135deg);
+.utc-sidebar .sidebar-menu .more svg {
+  transition: var(--utc-transition);
+}
+.utc-sidebar .sidebar-menu .open > .more i, .utc-sidebar .sidebar-menu .open > .more svg {
+  transform: rotate(90deg);
+  top: 6px;
+  position: absolute;
 }
 .utc-sidebar .more{
   /* color: gray; */
    /* text-gray-800; */
   @apply text-yellow-500;
-  transition: transform 0.3s;
+  transition: var(--utc-transition);
+  position: absolute;
+  height: 100%;
+  right: 6px;
+  top: 18px;
 }
 .utc-sidebar .more {
   float: right;

--- a/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
+++ b/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
@@ -1,51 +1,43 @@
 .utc-sidebar ol, .utc-sidebar ul {
-  list-style: none;
-  padding-left: 0;
+  @apply list-none pl-0;
 }
 .utc-sidebar ol li, .utc-sidebar ul li {
-  margin-bottom: 0.3em;
+  @apply mb-1;
 }
 .utc-sidebar ol li ul li, .utc-sidebar ul li ul li {
-  margin: 0.3em auto;
+  @apply my-1 mx-auto;
 }
 .utc-sidebar ol li ul li:first-child, .utc-sidebar ul li ul li:first-child {
-  border-top: none;
+  @apply border-t-0;
 }
 .utc-sidebar ol li ul li ul li, .utc-sidebar ul li ul li ul li {
-  margin: 0.3em auto;
+  @apply my-1 mx-auto;
 }
 .utc-sidebar ol li ul li ul li:first-child, .utc-sidebar ul li ul li ul li:first-child {
-  border-top: none;
+  @apply border-t-0;
 }
 .utc-sidebar .sidebar-menu li {
-  position: relative;
+  @apply relative;
 }
 .utc-sidebar .sidebar-menu li ul {
-  display: block;
-  max-height: 0;
-  overflow: hidden;
-  transition: all 0.3s ease;
+  @apply block max-h-0 overflow-hidden;
+  transition: var(--utc-transition);
 }
 .utc-sidebar .sidebar-menu li ul .menu-item-sidemenu a {
   @apply bg-utc-new-blue-100;
 }
 .utc-sidebar .sidebar-menu li ul .menu-item-sidemenu a:hover {
   @apply bg-utc-new-blue-200 text-utc-new-blue-500;
-  /* color: white;
-  background-color: darkgray; */
 }
 .utc-sidebar .menu-item-sidemenu.open > a {
   @apply bg-utc-new-blue-500 text-white
 }
 .utc-sidebar .menu-btn {
-  /* background: lightblue; */
-  @apply bg-utc-new-blue-100;
-  text-align: center;
+  @apply bg-utc-new-blue-100 text-center;
   cursor: s-resize;
 }
 .utc-sidebar .menu-btn img {
-  vertical-align: middle;
-  height: 50px;
+  @apply align-middle h-16;
 }
 .utc-sidebar .menu-open, .utc-sidebar .sidebar-menu .open > ul {
   max-height: 2000px;
@@ -54,81 +46,66 @@
   transition: var(--utc-transition);
 }
 .utc-sidebar .sidebar-menu .open > .more i, .utc-sidebar .sidebar-menu .open > .more svg {
+  @apply absolute;
   transform: rotate(90deg);
-  position: absolute;
 }
 .utc-sidebar .more{
-  /* color: gray; */
-   /* text-gray-800; */
-  @apply text-yellow-500;
+  @apply text-yellow-500 absolute right-2 top-0 bottom-0 flex items-center float-right cursor-pointer;
   transition: var(--utc-transition);
-  position: absolute;
-  height: 100%;
-  right: 6px;
-  top: 18px;
-}
-.utc-sidebar .more {
-  float: right;
   min-width: 8%;
-  cursor: pointer;
+  height: 3.75rem;
 }
 .menu-item-sidemenu a {
-  @apply bg-white;
-  @apply text-utc-new-blue-500;
-  font-weight: 500;
-  border: 1px solid;
-  @apply border-gray-400;
-  display: block;
-  padding: 1rem 1.2rem;
+  @apply bg-white text-utc-new-blue-500 border border-gray-400 font-normal block py-4 px-5;
 }
 .menu-item-sidemenu a:hover {
-  @apply bg-utc-new-blue-500;
-  @apply text-utc-new-gold-500;
-  text-decoration: none;
+  @apply bg-utc-new-blue-500 text-utc-new-gold-500 no-underline;
 }
-/* .utc-sidebar .menu-item-sidemenu a:hover .more {
-  @apply text-white;
-} */
 .menu-item-sidemenu .is-active {
-  @apply bg-utc-new-blue-500 !important;
-  @apply text-utc-new-gold-500;
-  text-decoration: none;
+  @apply bg-utc-new-blue-500 !important text-utc-new-gold-500 no-underline;
 }
-/* .utc-sidebar .menu-item--active-trail .more{
-  @apply text-white;
-  transition: transform 0.3s;
-} */
+/**subordinate active buttons in submenus to parent***/
+li.menu-item-sidemenu li.menu-item-sidemenu  .is-active {
+  @apply bg-utc-new-blue-200 !important text-utc-new-blue-500 !important;
+}
+li.menu-item-sidemenu li.menu-item-sidemenu  .is-active:before {
+  @apply mr-2 font-bold text-2xl;
+  content: "›";
+}
+
 @media (min-width: 991px) {
   input#mobile_menu {
-    display: none;
+    @apply hidden;
  }
   .section_menu {
-    display: none;
+    @apply hidden;
  }
 }
 @media (max-width: 991px) {
   .menu-content {
-    padding: 0 0 0 50px;
+    @apply py-0 pr-0 pl-16;
  }
   .section_menu {
-    @apply bg-utc-new-gold-500;
-    padding: 5px 30px;
-    @apply text-gray-800;
-    cursor: pointer;
-    user-select: none;
+    @apply bg-utc-new-gold-500 py-2 px-10 text-utc-new-blue-500 cursor-pointer select-none;
  }
   input#mobile_menu {
-    display: none;
+    @apply hidden;
  }
   .utc-sidebar {
-    max-height: 0;
-    overflow: hidden;
+    @apply max-h-0 overflow-hidden;
  }
   input:checked ~ .utc-sidebar {
-    max-height: 100%;
+    @apply max-h-full;
  }
+ .utc-sidebar .more {
+   @apply -right-6;
+  }
 }
-
+@media (max-width: 640px) {
+  .utc-sidebar .more {
+    @apply right-0;
+   }
+}
 /* 
 HR MENU
 .menu-item-topmenu .menu-item--active-trail .open {

--- a/source/default/_patterns/00-protons/legacy/js/utc-sidebar-menu.js
+++ b/source/default/_patterns/00-protons/legacy/js/utc-sidebar-menu.js
@@ -11,7 +11,7 @@
             })
             var menux = $('.sidebar-menu li a.parent');
             if ($('.more').length === 0) {
-                $('<div aria-hidden="true" class="more closed"><i class="fas fa-plus"></i></div>').insertBefore(menux);
+                $('<div aria-hidden="true" class="more closed"><i class="fas fa-angle-right"></i></div>').insertBefore(menux);
             };
             $('.menu-btn').click(function() {
                 $('nav').toggleClass('menu-open');


### PR DESCRIPTION
This PR makes one fix and several updates for better UX/UI. This is only temporary until we implement new branding styles.

**Most important fix:** Rotate the submenu indicator upon open.

**Before:**

- Plus submenu indicator.
- Parent with open submenu does not change color, which confuses the user as to which menu is open.
- Rollovers on submenu are dark gray? Not UTC colors.

Parent menu is not obvious:
![Screen Shot 2022-04-25 at 9 40 30 AM](https://user-images.githubusercontent.com/82905787/165103361-7fa8d0a2-54b6-4b67-8cfd-4ae5b4e9df0c.png)

Rollovers are dk gray:
![Screen Shot 2022-04-25 at 9 42 28 AM](https://user-images.githubusercontent.com/82905787/165103402-c26894c5-1477-4d61-8bda-2f62c8fd8d73.png)

**After:**
-Plus has been changed to right angle for better intuitive UI.
-Right angle rotates to down position upon menu open.
-Parent changes color to indicate which submenu is open.
-Rollover colors line up with UTC brand colors.
-Subordinated active buttons in submenus to parent while indicating active status.
-Converted existing CSS to TailwindCSS.
-ALL contrasts have been checked and passed regarding accessibility.

**Parent is dk blue with white text. Rollover in submenu is medium blue bg.:**
![Screen Shot 2022-04-25 at 9 41 53 AM](https://user-images.githubusercontent.com/82905787/165103909-e9dce000-b7bc-414c-bedc-fdc678a00158.png)

**Rollover of parent siblings remains unchanged.:**
![Screen Shot 2022-04-25 at 9 42 06 AM](https://user-images.githubusercontent.com/82905787/165104040-5dfda5a5-23cf-4512-8449-799cfd62487f.png)

**Active buttons in submenus are subordinated to parent while still indicating active status.**
![Screen Shot 2022-04-25 at 11 33 41 AM](https://user-images.githubusercontent.com/82905787/165123445-e9e5cafa-5c09-42d3-bfdd-16c949a5b706.png)


