### PR TITLE
UTC-458: Change empty block message.

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
+++ b/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
@@ -28,9 +28,10 @@
 }
 .utc-sidebar .sidebar-menu li ul .menu-item-sidemenu a:hover {
   @apply bg-utc-new-blue-200 text-utc-new-blue-500;
+  transition: var(--utc-transition);
 }
 .utc-sidebar .menu-item-sidemenu.open > a {
-  @apply bg-utc-new-blue-500 text-white
+  @apply bg-utc-new-blue-500 text-utc-new-gold-500;
 }
 .utc-sidebar .menu-btn {
   @apply bg-utc-new-blue-100 text-center;
@@ -57,9 +58,10 @@
 }
 .menu-item-sidemenu a {
   @apply bg-white text-utc-new-blue-500 border border-gray-400 font-normal block py-4 px-5;
+  transition: var(--utc-transition);
 }
 .menu-item-sidemenu a:hover {
-  @apply bg-utc-new-blue-500 text-utc-new-gold-500 no-underline;
+  @apply bg-utc-new-blue-500 text-white no-underline;
 }
 .menu-item-sidemenu .is-active {
   @apply bg-utc-new-blue-500 !important text-utc-new-gold-500 no-underline;
@@ -69,7 +71,8 @@ li.menu-item-sidemenu li.menu-item-sidemenu  .is-active {
   @apply bg-utc-new-blue-200 !important text-utc-new-blue-500 !important;
 }
 li.menu-item-sidemenu li.menu-item-sidemenu  .is-active:before {
-  @apply mr-2 font-bold text-2xl;
+  @apply mr-2 font-bold text-base;
+  line-height: 0;
   content: "→";
 }
 
@@ -106,7 +109,6 @@ li.menu-item-sidemenu li.menu-item-sidemenu  .is-active:before {
     @apply right-0;
    }
 }
-
 .user-logged-in .empty-menu-block {
 	min-height: 60px;
   background: aqua;
@@ -129,7 +131,7 @@ li.menu-item-sidemenu li.menu-item-sidemenu  .is-active:before {
   clip: unset;
 }
 .user-logged-in .empty-menu-block:before {
-  content: "Placeholder for the Menu_block configure or remove it.";
+  content: "Empty menu block. Please remove.";
   color: #000;
   height: 24px;
   font-size: 18px;


### PR DESCRIPTION
The arrow on the active sidebar submenu button is slightly off and a bit too large.

Other sidebar menu notes:

- Hovers: Need soft transitions
- Hierarchy of importance: Active parent should be gold text while its rollover siblings should be white text.
- Change the message of the empty menu block.

BEFORE:

![before](https://user-images.githubusercontent.com/82905787/167166755-928ceeac-1dc8-4012-9274-58b63f169842.gif)


AFTER:

![after](https://user-images.githubusercontent.com/82905787/167166776-1a5ba448-83bd-41ef-b3b1-8b6706b19628.gif)

