### PR TITLE
UTC-462: Scroll to hash adj for sticky header.

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/global.css
+++ b/source/default/_patterns/00-protons/legacy/css/global.css
@@ -472,6 +472,10 @@ ul.pager__items li a:hover {
   .page-search .container {
     margin-top: 1rem!important;
   }
+  a:not([href]):before {
+      height: 72px;
+      margin-top: -72px;
+  }
 }
 @media screen and (max-width: 640px) {
   h1{ font-size:28px!important;line-height:1.2em;}

--- a/source/default/_patterns/00-protons/legacy/css/global.css
+++ b/source/default/_patterns/00-protons/legacy/css/global.css
@@ -262,6 +262,14 @@ a:focus {
 a.focus-visible, a:focus-visible {
   outline: 2px dashed #fdb736;
 }
+a:not([href])::before {
+  content: '';
+  display: block;
+  height:      175px;
+  margin-top: -175px;
+  visibility: hidden;
+}
+
 .utc-card-2__text a:not(.btn):not(.ckeditor-accordion-toggler),
 .utc-sidebar-card a:not(.btn):not(.ckeditor-accordion-toggler),
 .utc-item-card a:not(.btn):not(.ckeditor-accordion-toggler) {


### PR DESCRIPTION
This is in regards to https://utc.teamdynamix.com/TDNext/Apps/3035/Tickets/TicketDet?TicketID=19220461

The hashtag is scrolled to the top and now has adjustments in css to accommodate the sticky header.

Before:
![Screen Shot 2022-05-18 at 11 44 36 AM](https://user-images.githubusercontent.com/82905787/169103473-da847480-5dc1-4fc9-a316-7cb6bed92529.png)

After:

Desktop:
![desktop](https://user-images.githubusercontent.com/82905787/169138990-591ca07e-2b15-4703-9c3e-e71c25053d35.gif)



Mobile:
![mobile](https://user-images.githubusercontent.com/82905787/169138976-c3b44156-fd65-45ed-8bf6-c4863c0f3cc9.gif)

