### PR TITLE
UTC-462: Limit the css properties to ckeditor only.

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/global.css
+++ b/source/default/_patterns/00-protons/legacy/css/global.css
@@ -262,12 +262,11 @@ a:focus {
 a.focus-visible, a:focus-visible {
   outline: 2px dashed #fdb736;
 }
-a:not([href])::before {
+.field--type-text-with-summary a:not([href]):before {
+  @apply block invisible;
   content: '';
-  display: block;
   height:      175px;
   margin-top: -175px;
-  visibility: hidden;
 }
 
 .utc-card-2__text a:not(.btn):not(.ckeditor-accordion-toggler),
@@ -472,7 +471,7 @@ ul.pager__items li a:hover {
   .page-search .container {
     margin-top: 1rem!important;
   }
-  a:not([href]):before {
+  .field--type-text-with-summary a:not([href]):before {
       height: 72px;
       margin-top: -72px;
   }


### PR DESCRIPTION
This PR is augments https://github.com/UTCWeb/particle/pull/463 and limits the class properties to ckeditor only by adding the  `.field--type-text-with-summary` class.
