### PR TITLE
UTC-458: Update accessibility for active  button.

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
+++ b/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
@@ -89,10 +89,7 @@
 .utc-sidebar .sidebar-menu li ul .menu-item-sidemenu a {
   @apply bg-utc-new-blue-100 text-utc-new-blue-500;
 }
-.utc-sidebar .sidebar-menu li ul .menu-item-sidemenu.open a.parent {
-  @apply bg-utc-new-blue-200;
-  transition: var(--utc-transition);
-}
+.utc-sidebar .sidebar-menu li ul .menu-item-sidemenu.open a.parent,
 .utc-sidebar .sidebar-menu li ul .menu-item-sidemenu a:hover {
   @apply bg-utc-new-blue-200 text-utc-new-blue-500;
   transition: var(--utc-transition);


### PR DESCRIPTION
While the accessibility of the gold text was fixed for non-active-trail buttons, it did not apply to active-trail buttons. The type was still gold, reducing the contrast and accessibility. This PR fixes that with a slight CSS change.

BEFORE: 
<img width="1574" alt="Screen Shot 2022-05-22 at 12 22 43 AM" src="https://user-images.githubusercontent.com/39039024/169678544-7371e77f-1255-474a-b654-050da7380a3f.png">

AFTER:
![Screen Shot 2022-05-23 at 10 59 11 AM](https://user-images.githubusercontent.com/82905787/169886052-0b48d9c9-40d2-431f-a86a-fcb583c72ff0.png)

