### PR TITLE
UTC-2264: Include collapsed class in effects.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/navigation/menu--utc-sidemenu.html.twig
+++ b/apps/drupal-default/particle_theme/templates/navigation/menu--utc-sidemenu.html.twig
@@ -43,7 +43,7 @@
           item.in_active_trail ? 'menu-item--active-trail open',
       ]
       %}
-      {% if item.is_expanded %}
+      {% if item.is_expanded or item.is_collapsed %}
         {% if item.in_active_trail %}
           <li{{ item.attributes.addClass(classes) }} >
             {{ link(item.title, item.url) }}

--- a/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
+++ b/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
@@ -29,18 +29,28 @@
 
 /****base menu attributes***/
 .menu-item-sidemenu a {
-  @apply bg-white text-utc-new-blue-500 border border-gray-400 font-normal block py-4 px-5;
+  @apply bg-white text-utc-new-blue-500 border border-gray-400 font-normal block py-4 pl-5 pr-8;
   transition: var(--utc-transition);
   width:96%;
 }
 .menu-item-sidemenu a:hover {
   @apply bg-utc-new-blue-500 text-white no-underline;
 }
+.menu-item-sidemenu a:hover .more svg {
+  @apply text-white;
+}
+.menu-item-sidemenu a:hover {
+  @apply bg-utc-new-blue-500 text-white no-underline;
+}
+.menu-item-sidemenu a:hover .more svg {
+  @apply text-white;
+}
 .utc-sidebar .menu-item-sidemenu > .more svg,
 .utc-sidebar .menu-item-sidemenu > .more.closed svg,
 .utc-sidebar .menu-item-sidemenu > .more.open svg {
   transition: var(--utc-transition);;
 }
+
 /***base chevron/more attributes***/
 .utc-sidebar .more{
   @apply text-utc-new-blue-500 absolute right-2 top-0 bottom-0 flex items-center float-right cursor-pointer;
@@ -50,7 +60,14 @@
 }
 .utc-sidebar .menu-item--active-trail > .more svg {
   @apply text-utc-new-blue-500;
-  transition: var(--utc-transition);
+}
+.utc-sidebar .menu-item--expanded a + .more,
+.utc-sidebar .menu-item--collapsed a + .more {
+  transition:unset;
+}
+.utc-sidebar .menu-item--expanded a:hover + .more,
+.utc-sidebar .menu-item--collapsed a:hover + .more {
+  @apply text-white;
 }
 .utc-sidebar .menu-item--active-trail > .more, .utc-sidebar .menu-item--active-trail  > .more svg {
   @apply text-utc-new-gold-500;


### PR DESCRIPTION
Three issues:

1. Arrows on rollovers not working:

**Before:**
![menu-rollover-issue-1](https://user-images.githubusercontent.com/82905787/194160613-4df6bdd2-e7b7-409d-94b9-5ca0633cf6e6.gif)

**After:** 
![menu-issue-1-fixed](https://user-images.githubusercontent.com/82905787/194160647-46ee6541-1d16-484a-9dba-6d264578c265.gif)


2. Collapse class needs effects applied to sidebar menu.

**Before:**
![menu-issue-2](https://user-images.githubusercontent.com/82905787/194160711-ee2d09d9-387b-495f-adfb-39820370a0f3.gif)

**After:**
![menu-issue-2-fixed](https://user-images.githubusercontent.com/82905787/194160788-5c92bd0d-ccf4-41ab-978b-8f4d828bae56.gif)

3. Need to shorten anchor element to give space betwee long menu text and arrows.