### PR TITLE
UTC-2264: Color change to indicate expansion.

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
+++ b/source/default/_patterns/00-protons/legacy/css/utc-sidebar-menu.css
@@ -50,7 +50,10 @@
 .utc-sidebar .menu-item-sidemenu > .more.open svg {
   transition: var(--utc-transition);;
 }
-
+.menu-item--expanded li.menu-item-sidemenu.menu-item--expanded.open > a,
+.menu-item--expanded li.menu-item-sidemenu.menu-item--active-trail > a {
+  background-color: rgba(196,203,212,var(--tw-bg-opacity));
+}
 /***base chevron/more attributes***/
 .utc-sidebar .more{
   @apply text-utc-new-blue-500 absolute right-2 top-0 bottom-0 flex items-center float-right cursor-pointer;


### PR DESCRIPTION
Change the background color of buttons with open submenus under the active trail or a parent expanded trail.

**Before: Color is not distinct with expanded submenus as shown with "Student Success" and "Veteran's Entrepreneurship Program".**
![Screen Shot 2022-10-06 at 8 36 35 AM](https://user-images.githubusercontent.com/82905787/194314591-d00780bb-8b59-42c8-97ed-7e2670d42408.png)


**After: Color adds a better path indicator of what the user is viewing as shown with "Student Success" and "Veteran's Entrepreneurship Program".**
![Screen Shot 2022-10-06 at 8 36 02 AM](https://user-images.githubusercontent.com/82905787/194314586-1631921b-b1de-49ae-877e-343201063b43.png)

