### PR TITLE
UTC-495: Change newsroom feed direction.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/views/views-view-unformatted--utc-newsroom--utc_newsroom_titles.html.twig
+++ b/apps/drupal-default/particle_theme/templates/views/views-view-unformatted--utc-newsroom--utc_newsroom_titles.html.twig
@@ -21,7 +21,7 @@
 		{{ title }}
 	</h3>
 {% endif %}
-<div class="md:grid md:grid-flow-col md:grid-cols-3 md:grid-rows-3 md:gap-8 ml-2">
+<div class="md:grid md:grid-cols-3 md:grid-rows-3 md:gap-8 ml-2">
 	{% for key,row in rows %}
 		{% set content = {
 	news_link: view.style_plugin.getField(key, 'field_utc_rss_feed_item_link')|striptags|trim,


### PR DESCRIPTION
UTC-495: Change newsroom feed direction from grid columns to rows.

Before:
![Screen Shot 2022-10-17 at 2 44 07 PM](https://user-images.githubusercontent.com/82905787/196257431-1e46f985-607a-4d65-a447-35aa14452973.png)


After:
![Screen Shot 2022-10-17 at 2 44 11 PM](https://user-images.githubusercontent.com/82905787/196257447-774edf68-7ac1-4f54-b177-20edd1fb8d86.png)

