### PR TITLE
UTC-500: Make copyright in the footer dynamic.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--block-content--copyrightnotice-particle.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--block-content--copyrightnotice-particle.html.twig
@@ -1,0 +1,42 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+<div{{ attributes }}>
+  {{ title_prefix }}
+    {% if label %}
+      <h2{{ title_attributes }}>
+         <span class="title-text">{{ label }}</span>
+      </h2>
+    {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    <div{{ content_attributes }}>
+        <p style="color:#FFF;"><a href="https://www.utc.edu/about/contact/" id="legal-questions">Questions?</a> © 2012-{{ 'now'|date('Y') }} University of Tennessee at Chattanooga. All rights reserved.</p>
+        {{ content }}
+    </div>
+  {% endblock %}
+</div>


### PR DESCRIPTION
Assuming that the copyright text will remain the same except the year, it's best if the year is dynamically updated. This year the "2021" went undetected and unchanged until 11/4/2022. It is correct now and dynamic with this PR. Only the first line is dynamic. The rest remains static in the custom block.

![Screen Shot 2022-11-07 at 10 40 58 AM](https://user-images.githubusercontent.com/82905787/200351883-f876c1cc-94b8-4795-8be6-4cd9fe9c8408.png)
