### PR TITLE
UTC-502: Wrap tags mobile and adjust form footer.

### DIFF
--- a/source/default/_patterns/00-protons/index.js
+++ b/source/default/_patterns/00-protons/index.js
@@ -41,6 +41,7 @@ import './legacy/css/digital_measures/tabbed.css';
 import './legacy/css/pages/utc_homepages_options.css';
 import './legacy/css/pages/utc_error_pages.css';
 import './legacy/css/components/UTC-custom-blocks/_utc_hover_images.css';
+import './legacy/css/components/field/_field--block-content--field-tags.css';
 // import "./legacy/css/components/UTC-custom-blocks/";
 // import "./legacy/css/components/field/";
 

--- a/source/default/_patterns/00-protons/legacy/css/components/field/_field--block-content--field-tags.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/field/_field--block-content--field-tags.css
@@ -1,0 +1,5 @@
+@media screen and (max-width: 640px) {
+    .field--name-field-tags .field__items, .field--name-field-mg-tags .field__items {
+        flex-wrap: wrap;
+    }
+}

--- a/source/default/_patterns/00-protons/legacy/css/footer.css
+++ b/source/default/_patterns/00-protons/legacy/css/footer.css
@@ -76,7 +76,8 @@
   @apply text-white text-left text-base capitalize leading-loose;
 }
 
-.path-search .footer-bottom-wrapper .row {
+.path-search .footer-bottom-wrapper .row,
+.path-webform .footer-bottom-wrapper .row {
   align-content: unset!important;
   justify-content: unset!important;
   @apply my-0 mx-auto block;


### PR DESCRIPTION
This PR solves issue #502:

Webform pages footer:
![Screen Shot 2022-11-18 at 9 19 27 AM](https://user-images.githubusercontent.com/82905787/202725905-0f14bb5d-14b1-4c16-bce2-813f71061770.png)

Tags now wrap on mobile:
![Screen Shot 2022-11-18 at 9 17 56 AM](https://user-images.githubusercontent.com/82905787/202726008-71ce41a2-9da8-4e82-ae32-fa2b40401dcb.png)
