### PR TITLE
UTC-468: Edits for video hero and image hero.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
@@ -38,55 +38,53 @@
 	{% endif %}
 	{# Sets colors for hero content depending on selection #}
 	{% if utc_hero.hero_color == 'Dark Blue' %}
-		{% set title_color = 'lg:text-white' %}
 		{% set bg_color = 'background-color:#112e51' %}
 		{% set bg1_opacity = '' %}
     	{% set bg2_opacity = 'opacity-90' %}
-		{% set body_color = 'lg:text-white' %}
-		{% set tag_color ='lg:text-white' %}
+		{% set title_color = 'text-white' %}
+		{% set body_color = 'text-white' %}
+		{% set tag_color ='text-white' %}
 	{% else %}
 		{% set title_color = 'text-utc-new-blue-500' %}
 		{% set bg_color = 'background-color:#104dd4' %}
 		{% set bg1_opacity = 'opacity-20' %}
     	{% set bg2_opacity = 'opacity-20' %}
-		{% set tag_color ='lg:text-base' %}
+		{% set tag_color ='text-utc-new-blue-500' %}
+		{% set body_color = 'text-utc-new-blue-500' %}
 		{% set btn_class = "light-gray-hero" %}
 	{% endif %}
-	{% set body_color = 'text-base' %}
+
 	{% set btn_border_color = "lg:border-utc-new-blue-500" %}
 	{% set btn_color = "lg:text-base" %} 
 		 
 	{% if utc_hero.hero_align == 'Left' %}
-		<div class="utc-hero-block lg:grid lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-4 lg:grid-flow-row lg:mb-4 lg:pb-8 text-center shadow-utc">
+		<div class="utc-hero-block text-center shadow-utc relative p-12">
+			<div class="interior-container flex flex-col lg:grid lg:grid-cols-utcvideohero lg:grid-flow-col lg:gap-10 items-center">
 			{% if utc_hero.hero_image %}
-				<div class="lg:col-start-2 lg:col-end-3 lg:row-start-2 lg:row-end-6 lg:m-auto col-span-1 z-30 {{ utc_zoom }} shadow-utcdark relative">
+				<div class="lg:m-auto z-30 {{ utc_zoom }} relative" >
 					{{ utc_hero.hero_image }} 
 				</div>
 			{% endif %}
-				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-3 lg:ml-8 p-4 z-30 self-end relative">
+				<div class=" p-4 z-30 relative">
 	{% else %}
-		<div class="utc-hero-block lg:grid lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-6 grid-flow-row lg:mb-4 text-center">
+		<div class="utc-hero-block .utc-hero-image-default text-center shadow-utc relative p-12">
+			<div class="interior-container flex flex-col lg:grid lg:grid-cols-utcvideoheroright lg:grid-flow-col lg:gap-10 items-center">
 			{% if utc_hero.hero_image %}
-				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto z-30 {{ utc_zoom }} shadow-utcdark relative">
+				<div class="z-30 {{ utc_zoom }} relative order-last " >
 					{{ utc_hero.hero_image }}
 				</div>
 			{% endif %}
-				<div class="lg:col-start-2 lg:col-end-2 lg:row-start-2 lg:row-end-3 lg:mr-8 p-4 pt-0 col-span-1 z-30 self-end relative">
+				<div class="lg:mr-8 p-4 pt-0 z-30 relative order-first">
 	{% endif %}
 				{% block herotagtitle %}
 					{{ parent() }}
 				{% endblock herotagtitle %}
-				</div>
-			{% if utc_hero.hero_align == 'Left' %}
-				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-3 lg:row-end-4 lg:mr-8 lg:ml-8 p-4 pt-0 col-span-1 z-30">
-			{% else %}
-				<div class="lg:col-start-2 lg:col-end-3 lg:row-start-3 lg:row-end-4 lg:mr-8 p-4 pt-0 col-span-1 z-30">
-			{% endif %}
 				{% block herotextbutton %}
 					{{ parent() }}
 				{% endblock herotextbutton %}
 				</div>
-			<div class="lg:max-w-full lg:ml-0 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-3" style="background-image: url({{ utc_hero.hero_bg }})">
+			</div>
+			<div class="lg:max-w-full lg:ml-0 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 absolute top-0 left-0" style="background-image: url({{ utc_hero.hero_bg }})">
 				<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
 			</div>
 		</div>

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
@@ -41,8 +41,8 @@
     	{% set bg2_opacity = 'opacity-90' %}
 	{% else %}
 		{% set title_color = 'text-utc-new-blue-500' %}
-		{% set body_color = 'text-base' %}
-		{% set tag_color = 'text-base' %}
+		{% set body_color = 'text-utc-new-blue-500' %}
+		{% set tag_color = 'text-utc-new-blue-500' %}
 		{% set btn_border_color = "border-utc-new-blue-500" %}
 		{% set btn_class = "light-gray-hero" %}
 		{% set bg_color = 'background-color:#104dd4' %}
@@ -84,12 +84,12 @@
 					{% endblock herotagtitle %}
 					{% block herotextbutton %}
 						{% if utc_hero.hero_text %}
-							<p class="text-left text-lg text-base {{ body_color }}">
+							<p class="text-left text-lg {{ body_color }}">
 								{{ utc_hero.hero_text}}
 							</p>
 						{% endif %}
 						{% if utc_hero.hero_button_url %}
-							<p class="my-6 text-right">
+							<p class="my-8 text-right">
 								<a href="{{ utc_hero.hero_button_url}}"  class="diagonal {{ btn_class }}" aria-label="Read the release">
 									{{ utc_hero.hero_button_text }} <i class="fas fa-angle-right font-semibold ml-1"></i>
 								</a>

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero-video--default.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero-video--default.html.twig
@@ -35,7 +35,7 @@
 			hero_color: content["#block_content"].field_hero_color.0.value,
 			hero_tag: content.field_hero_tag_text|field_value,
 			hero_title: content.field_hero_title|field_value,
-			hero_video: content.field_video,
+			hero_video: content.field_video_hero,
 			hero_text: content.field_hero_text|field_value,
 			hero_button_text: content.field_hero_button.0['#title'],
 			hero_button_url: content.field_hero_button.0['#url'],
@@ -140,6 +140,5 @@
 				</div>
 			{% endblock herobackgroundright %}		
 		{% endif %}
-		</div>
 	{% endblock %}
 </div>

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero-video--full-center.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero-video--full-center.html.twig
@@ -38,7 +38,7 @@
 			hero_color: content["#block_content"].field_hero_color.0.value,
 			hero_tag: content.field_hero_tag_text|field_value,
 			hero_title: content.field_hero_title|field_value,
-			hero_video: content.field_video,
+			hero_video: content.field_video_hero,
 			hero_text: content.field_hero_text|field_value,
 			hero_button_text: content.field_hero_button.0['#title'],
 			hero_button_url: content.field_hero_button.0['#url'],
@@ -69,14 +69,14 @@
 		{# image on left #}
 		{% if utc_hero.hero_align == 'Left' %}
 			{% block herobackgroundleft %}
-				<div class="video-hero-wrapper left h-full lg:ml-12 p-12 lg:pl-0 relative">
-					<span class="absolute left-0 top-0 right-0 bottom-0 {{ bg1_opacity }} bg-cover bg-center" style="background-image: url({{ utc_hero.hero_bg }})"></span>
-					<div class="absolute left-0 top-0 hero-background-color h-full w-full " style="{{ bg2_opacity }} {{ bg_color }}"></div>
-					<div class="utc-video-hero-container utc-video-hero-block-left flex flex-col lg:grid lg:grid-cols-utcvideohero lg:gap-10 relative ">
+				<div class="video-hero-wrapper left h-full p-12 lg:pl-0 relative">
+					<div class="absolute top-0 right-0 bottom-0 lg:max-w-95p overflow-x-hidden {{ bg1_opacity }} bg-cover bg-center w-full" style="background-image: url({{ utc_hero.hero_bg }})"></div>
+					<div class="absolute right-0 top-0 hero-background-color h-full lg:max-w-95p overflow-x-hidden w-full" style="{{ bg2_opacity }} {{ bg_color }} "></div>
+					<div class="utc-video-hero-container utc-video-hero-block-left w-full flex flex-col-reverse lg:grid lg:gap-10 relative" style="grid-template-columns: 71% 30%!important;">
 						<div class="flex flex-column justify-center">
 							<div class="video-hero {{ utc_hero.hero_parameters[0] }} {{ utc_hero.hero_parameters[1] }} {{ utc_hero.hero_parameters[2] }} {{ utc_hero.hero_parameters[3] }} ">{{ utc_hero.hero_video }}{{ utc_hero.hero_otherhost }}</div>
 						</div>
-						<div class="flex flex-col justify-center shrink relative">
+						<div class="flex flex-col justify-center shrink relative pr-16">
 							{% if utc_hero.hero_tag %}
 								<p class="text-left font-semibold tracking-wide uppercase text-lg mb-0 mt-4 {{ tag_color }}">
 									{{ utc_hero.hero_tag }}
@@ -107,10 +107,10 @@
 		{% else %}
 		{# image on right #}	
 			{% block herobackgroundright %}
-				<div class="video-hero-wrapper right h-full p-12 lg:pl-0 relative">
-					<span class="absolute left-0 top-0 right-0 bottom-0 {{ bg1_opacity }} bg-cover bg-center" style="background-image: url({{ utc_hero.hero_bg }})"></span>
-					<div class="absolute left-0 top-0 hero-background-color h-full w-full " style="{{ bg2_opacity }} {{ bg_color }}"></div>
-					<div class="utc-video-hero-container utc-video-hero-block-right flex flex-col-reverse lg:grid lg:grid-cols-utcvideoheroright lg:gap-10 relative ">
+				<div class="video-hero-wrapper right h-full p-12 relative">
+					<div class="absolute left-0 top-0 right-0 bottom-0 lg:max-w-95p overflow-x-hidden {{ bg1_opacity }} bg-cover bg-center w-full" style="background-image: url({{ utc_hero.hero_bg }})"></div>
+					<div class="absolute left-0 top-0 hero-background-color h-full lg:max-w-95p overflow-x-hidden w-full" style="{{ bg2_opacity }} {{ bg_color }} "></div>
+					<div class="utc-video-hero-container utc-video-hero-block-right w-full flex flex-col-reverse lg:grid lg:gap-10 relative " style="grid-template-columns: 30% 71%!important;">
 						<div class="flex flex-col justify-center shrink relative">
 							{% if utc_hero.hero_tag %}
 								<p class="text-left font-semibold tracking-wide uppercase text-lg mb-0 mt-4 {{ tag_color }} lg:whitespace-nowrap">
@@ -143,6 +143,5 @@
 				</div>
 			{% endblock herobackgroundright %}		
 		{% endif %}
-		</div>
 	{% endblock %}
 </div>

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero-video--full-reverse.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero-video--full-reverse.html.twig
@@ -37,7 +37,7 @@
 			hero_color: content["#block_content"].field_hero_color.0.value,
 			hero_tag: content.field_hero_tag_text|field_value,
 			hero_title: content.field_hero_title|field_value,
-			hero_video: content.field_video,
+			hero_video: content.field_video_hero,
 			hero_text: content.field_hero_text|field_value,
 			hero_button_text: content.field_hero_button.0['#title'],
 			hero_button_url: content.field_hero_button.0['#url'],
@@ -142,6 +142,5 @@
 				</div>
 			{% endblock herobackgroundright %}		
 		{% endif %}
-		</div>
 	{% endblock %}
 </div>

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero-video--full.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero-video--full.html.twig
@@ -36,7 +36,7 @@
 			hero_color: content["#block_content"].field_hero_color.0.value,
 			hero_tag: content.field_hero_tag_text|field_value,
 			hero_title: content.field_hero_title|field_value,
-			hero_video: content.field_video,
+			hero_video: content.field_video_hero,
 			hero_text: content.field_hero_text|field_value,
 			hero_button_text: content.field_hero_button.0['#title'],
 			hero_button_url: content.field_hero_button.0['#url'],
@@ -141,6 +141,5 @@
 				</div>
 			{% endblock herobackgroundright %}		
 		{% endif %}
-		</div>
 	{% endblock %}
 </div>

--- a/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_hero_video.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_hero_video.css
@@ -6,43 +6,44 @@
 .utc-hero-region .contextual {@apply right-6}
 .block--utc-video-hero {@apply h-full overflow-visible relative;}
 
-.video-hero.youtube { @apply relative h-0 overflow-visible max-w-full;padding-bottom: 56.25%; } 
+.video-hero.responsive-video { @apply relative h-0 overflow-visible max-w-full;padding-bottom: 56.25%; } 
 
-.block--utc-video-hero-full .video-hero.youtube iframe, 
-.block--utc-video-hero-full .video-hero.youtube object, 
-.block--utc-video-hero-full .video-hero.youtube embed { @apply absolute left-0; }
+.block--utc-video-hero-full .video-hero.responsive-video iframe, 
+.block--utc-video-hero-full .video-hero.responsive-video object, 
+.block--utc-video-hero-full .video-hero.responsive-video embed { @apply absolute left-0; }
 
-.container .block--utc-video-hero-full .video-hero.youtube iframe, 
-.container .block--utc-video-hero-full .video-hero.youtube object, 
-.container .block--utc-video-hero-full .video-hero.youtube embed { top:6rem!important;}
+.container .block--utc-video-hero-full .video-hero.responsive-video iframe, 
+.container .block--utc-video-hero-full .video-hero.responsive-video object, 
+.container .block--utc-video-hero-full .video-hero.responsive-video embed { top:6rem!important;}
 
-.container-full .block--utc-video-hero-full .video-hero.youtube iframe, 
-.container-full .block--utc-video-hero-full .video-hero.youtube object, 
-.container-full .block--utc-video-hero-full .video-hero.youtube embed { top:4rem!important;}
+.container-full .block--utc-video-hero-full .video-hero.responsive-video iframe, 
+.container-full .block--utc-video-hero-full .video-hero.responsive-video object, 
+.container-full .block--utc-video-hero-full .video-hero.responsive-video embed { top:4rem!important;}
 
-.container-full .block--utc-video-hero-full-center .video-hero.youtube iframe, 
-.container-full .block--utc-video-hero-full-center .video-hero.youtube object, 
-.container-full .block--utc-video-hero-full-center .video-hero.youtube embed { top:0!important;}
+.container-full .block--utc-video-hero-full-center .video-hero.responsive-video iframe, 
+.container-full .block--utc-video-hero-full-center .video-hero.responsive-video object, 
+.container-full .block--utc-video-hero-full-center .video-hero.responsive-video embed { top:0!important;}
+
 
 .container-full .block--utc-video-hero .video-hero-wrapper {@apply pb-0;}
 .container .block--utc-video-hero .video-hero-wrapper {@apply pb-8;}
 
-.block--utc-video-hero-full-center .video-hero-wrapper {width:95%;}
-.block--utc-video-hero-full-center .video-hero-wrapper.left {margin-left:5%!important;}
-.block--utc-video-hero-full-center .utc-video-hero-block-left {margin-left:-5%;}
-.block--utc-video-hero-full-center .video-hero-wrapper.right {margin-right:5%;}
-.block--utc-video-hero-full-center .utc-video-hero-block-right {margin-left:5%;margin-right:-10%;}
+/*.block--utc-video-hero-full-center .video-hero-wrapper {width:98%;}
+.block--utc-video-hero-full-center .video-hero-wrapper.left {margin-left:3%!important;}
+.block--utc-video-hero-full-center .utc-video-hero-block-left {margin-left:-3%;}
+.block--utc-video-hero-full-center .video-hero-wrapper.right {margin-right:3%;}
+.block--utc-video-hero-full-center .utc-video-hero-block-right {margin-left:3%;margin-right:-7%;}*/
 
 .block--utc-video-hero-full {@apply mb-24;}
 
   
 @media (max-width:1023px) {
-    .container .block--utc-video-hero-full .video-hero.youtube iframe, 
-    .container .block--utc-video-hero-full .video-hero.youtube object, 
-    .container .block--utc-video-hero-full .video-hero.youtube embed,
-    .container-full .block--utc-video-hero-full .video-hero.youtube iframe, 
-    .container-full .block--utc-video-hero-full .video-hero.youtube object, 
-    .container-full .block--utc-video-hero-full .video-hero.youtube embed { top:0!important;}
+    .container .block--utc-video-hero-full .video-hero.responsive-video iframe, 
+    .container .block--utc-video-hero-full .video-hero.responsive-video object, 
+    .container .block--utc-video-hero-full .video-hero.responsive-video embed,
+    .container-full .block--utc-video-hero-full .video-hero.responsive-video iframe, 
+    .container-full .block--utc-video-hero-full .video-hero.responsive-video object, 
+    .container-full .block--utc-video-hero-full .video-hero.responsive-video embed { top:0!important;}
     .block--utc-video-hero-full .video-hero-wrapper {@apply pt-12} 
     .container-full .block--utc-video-hero .video-hero-wrapper,
     .container .block--utc-video-hero .video-hero-wrapper { @apply pb-12; }

--- a/source/default/_patterns/00-protons/legacy/css/global.css
+++ b/source/default/_patterns/00-protons/legacy/css/global.css
@@ -368,6 +368,7 @@ a.diagonal.light-gray-hero:hover i,
 a.diagonal.light-gray-hero:hover svg{
   @apply text-utc-new-gold-500;
 }
+
 b, strong {
   @apply font-bold;
 }
@@ -486,6 +487,18 @@ ul.pager__items li a:hover {
 
 @media screen and (max-width: 1024px) {
   .section-hero {@apply bg-white pt-6 }
+  .utc-hero-image-default .order-first, .utc-hero-image-default .order-last {
+    order: unset!important;
+  }
+  .utc-hero-image-default .order-first {
+    @apply mt-8;
+  }
+  .node__content > .section-hero:first-child {
+    @apply p-0 -mt-4
+  }
+  .node__content > .section-hero:first-child .themag-layout__region {
+    @apply p-0;
+  }
 }
 @media screen and (max-width: 768px) {
   main {
@@ -493,6 +506,9 @@ ul.pager__items li a:hover {
   }
   .container-full, .themag-layout--my-default {
     @apply px-4;
+  }
+  .section-hero .container-full {
+    @apply px-0;
   }
   .container-full .block--region-content-header.block--page-title-block .page-title {
     @apply text-lg;


### PR DESCRIPTION
These edits fix the following issues listed here https://github.com/UTCWeb/particle/issues/468:

1. The original "Default" for the image hero was a nice design, but it looked like a mistake. This PR normalizes it better:

![Screen Shot 2023-01-11 at 5 12 36 PM](https://user-images.githubusercontent.com/82905787/211932457-59af4337-0bf6-4d50-8c0a-8b9219d160ac.png)

2. The mobile version of the "Default" image hero has been color-corrected:

![Screen Shot 2023-01-11 at 5 12 50 PM](https://user-images.githubusercontent.com/82905787/211932512-4b2540c2-7b24-490b-901c-4784b0578e4d.png)

3. Only 1 video can be selected to the hero video.
![Screen Shot 2023-01-11 at 5 51 35 PM](https://user-images.githubusercontent.com/82905787/211935143-f4f41ff3-6168-4e5e-9cc9-ec3bfb981c72.png)

4. YouTube regex refactored to show YouTube videos:
![Screen Shot 2023-01-11 at 3 10 45 PM](https://user-images.githubusercontent.com/82905787/211935339-505fac17-7939-4a8f-9386-a24b9552d8d4.png)



