### PR TITLE
UTC-516: Add classes to image hero block.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
@@ -11,81 +11,96 @@
  * This template pulls in the variables to add to the hero. 
  * References the block--utc-hero--full.html.twig.
 #}
+{%
+  set classes = [
+	'block--utc-image-hero',
+	'block--utc-image-default',
+  ]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {{ title_prefix }}
+    {% if label %}
+      <h2{{ title_attributes }}>
+         <span class="title-text">{{ label }}</span>
+      </h2>
+    {% endif %}
+  {{ title_suffix }}
+	{% block content %}
+		{{ attach_library('utccloud/utc-hero-image') }}
+		{% set rendered_content = content|render %}
+		{# Sets variable to trigger content render array. #}
+		{# hero_button_link: content.field_hero_button|field_value, #}
+		{% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %}
+		{% set utc_hero = {
+		hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_image_select)["#object"].field_image_url.value,
+		hero_align: content["#block_content"].field_hero_align.0.value,
+		hero_color: content["#block_content"].field_hero_color.0.value,
+		hero_tag: content.field_hero_tag|field_value,
+		hero_title: content.field_hero_title|field_value,
+		hero_image: content.field_utc_media|field_value,
+		hero_zoom: content.field_zoom_image[0]|render == 'On' ? '_blank',
+		hero_text: content.field_hero_text|field_value,
+		hero_button_text: content.field_hero_button.0['#title'],
+		hero_button_url: content.field_hero_button.0['#url'],
+		} %}
+		{# Add zoom class if zoom is checked. #}
+		{% if utc_hero.hero_zoom %}
+			{% set utc_zoom = 'utc-zoom-image' %}
+		{% else %}
+			{% set utc_zoom = '' %}
+		{% endif %}
+		{# Sets colors for hero content depending on selection #}
+		{% if utc_hero.hero_color == 'Dark Blue' %}
+			{% set bg_color = 'background-color:#112e51' %}
+			{% set bg1_opacity = '' %}
+			{% set bg2_opacity = 'opacity-90' %}
+			{% set title_color = 'text-white' %}
+			{% set body_color = 'text-white' %}
+			{% set tag_color ='text-white' %}
+		{% else %}
+			{% set title_color = 'text-utc-new-blue-500' %}
+			{% set bg_color = 'background-color:#104dd4' %}
+			{% set bg1_opacity = 'opacity-20' %}
+			{% set bg2_opacity = 'opacity-20' %}
+			{% set tag_color ='text-utc-new-blue-500' %}
+			{% set body_color = 'text-utc-new-blue-500' %}
+			{% set btn_class = "light-gray-hero" %}
+		{% endif %}
 
-{% block content %}
-	{{ attach_library('utccloud/utc-hero-image') }}
-	{% set rendered_content = content|render %}
-	{# Sets variable to trigger content render array. #}
-	{# hero_button_link: content.field_hero_button|field_value, #}
-	{% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %}
-	{% set utc_hero = {
-	hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_image_select)["#object"].field_image_url.value,
-	hero_align: content["#block_content"].field_hero_align.0.value,
-	hero_color: content["#block_content"].field_hero_color.0.value,
-	hero_tag: content.field_hero_tag|field_value,
-    hero_title: content.field_hero_title|field_value,
-    hero_image: content.field_utc_media|field_value,
-	hero_zoom: content.field_zoom_image[0]|render == 'On' ? '_blank',
-    hero_text: content.field_hero_text|field_value,
-    hero_button_text: content.field_hero_button.0['#title'],
-    hero_button_url: content.field_hero_button.0['#url'],
-    } %}
-	{# Add zoom class if zoom is checked. #}
-	{% if utc_hero.hero_zoom %}
-		{% set utc_zoom = 'utc-zoom-image' %}
-	{% else %}
-		{% set utc_zoom = '' %}
-	{% endif %}
-	{# Sets colors for hero content depending on selection #}
-	{% if utc_hero.hero_color == 'Dark Blue' %}
-		{% set bg_color = 'background-color:#112e51' %}
-		{% set bg1_opacity = '' %}
-    	{% set bg2_opacity = 'opacity-90' %}
-		{% set title_color = 'text-white' %}
-		{% set body_color = 'text-white' %}
-		{% set tag_color ='text-white' %}
-	{% else %}
-		{% set title_color = 'text-utc-new-blue-500' %}
-		{% set bg_color = 'background-color:#104dd4' %}
-		{% set bg1_opacity = 'opacity-20' %}
-    	{% set bg2_opacity = 'opacity-20' %}
-		{% set tag_color ='text-utc-new-blue-500' %}
-		{% set body_color = 'text-utc-new-blue-500' %}
-		{% set btn_class = "light-gray-hero" %}
-	{% endif %}
-
-	{% set btn_border_color = "lg:border-utc-new-blue-500" %}
-	{% set btn_color = "lg:text-base" %} 
-		 
-	{% if utc_hero.hero_align == 'Left' %}
-		<div class="utc-hero-block text-center shadow-utc relative p-12">
-			<div class="interior-container flex flex-col lg:grid lg:grid-cols-utcvideohero lg:grid-flow-col lg:gap-10 items-center">
-			{% if utc_hero.hero_image %}
-				<div class="lg:m-auto z-30 {{ utc_zoom }} relative" >
-					{{ utc_hero.hero_image }} 
-				</div>
+		{% set btn_border_color = "lg:border-utc-new-blue-500" %}
+		{% set btn_color = "lg:text-base" %} 
+		<div {{ attributes.addClass(classes) }}>	
+			{% if utc_hero.hero_align == 'Left' %}
+				<div class="utc-hero-block text-center shadow-utc relative p-12">
+					<div class="interior-container flex flex-col lg:grid lg:grid-cols-utcvideohero lg:grid-flow-col lg:gap-10 items-center">
+					{% if utc_hero.hero_image %}
+						<div class="lg:m-auto z-30 {{ utc_zoom }} relative" >
+							{{ utc_hero.hero_image }} 
+						</div>
+					{% endif %}
+						<div class=" p-4 z-30 relative">
+			{% else %}
+				<div class="utc-hero-block .utc-hero-image-default text-center shadow-utc relative p-12">
+					<div class="interior-container flex flex-col lg:grid lg:grid-cols-utcvideoheroright lg:grid-flow-col lg:gap-10 items-center">
+					{% if utc_hero.hero_image %}
+						<div class="z-30 {{ utc_zoom }} relative order-last " >
+							{{ utc_hero.hero_image }}
+						</div>
+					{% endif %}
+						<div class="lg:mr-8 p-4 pt-0 z-30 relative order-first">
 			{% endif %}
-				<div class=" p-4 z-30 relative">
-	{% else %}
-		<div class="utc-hero-block .utc-hero-image-default text-center shadow-utc relative p-12">
-			<div class="interior-container flex flex-col lg:grid lg:grid-cols-utcvideoheroright lg:grid-flow-col lg:gap-10 items-center">
-			{% if utc_hero.hero_image %}
-				<div class="z-30 {{ utc_zoom }} relative order-last " >
-					{{ utc_hero.hero_image }}
+						{% block herotagtitle %}
+							{{ parent() }}
+						{% endblock herotagtitle %}
+						{% block herotextbutton %}
+							{{ parent() }}
+						{% endblock herotextbutton %}
+						</div>
+					</div>
+					<div class="lg:max-w-full lg:ml-0 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 absolute top-0 left-0" style="background-image: url({{ utc_hero.hero_bg }})">
+						<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
+					</div>
 				</div>
-			{% endif %}
-				<div class="lg:mr-8 p-4 pt-0 z-30 relative order-first">
-	{% endif %}
-				{% block herotagtitle %}
-					{{ parent() }}
-				{% endblock herotagtitle %}
-				{% block herotextbutton %}
-					{{ parent() }}
-				{% endblock herotextbutton %}
-				</div>
-			</div>
-			<div class="lg:max-w-full lg:ml-0 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 absolute top-0 left-0" style="background-image: url({{ utc_hero.hero_bg }})">
-				<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
-			</div>
 		</div>
 	{% endblock %}
+</div>

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-center.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-center.html.twig
@@ -11,7 +11,12 @@
  * This template pulls in the variables to add to the cards. 
  * References the block--utc-card-base.html.twig to create the individual cards in this grid.
 #}
-
+{%
+  set classes = [
+	'block--utc-image-hero',
+	'block--utc-image-hero-full-center',
+  ]
+%}
 {% block content %}
 	{{ attach_library('utccloud/utc-hero-image') }}
 	{% set rendered_content = content|render %}
@@ -55,34 +60,35 @@
 		{% set bg1_opacity = 'opacity-20' %}
     	{% set bg2_opacity = 'opacity-20' %}
 	{% endif %}
-		 
-	{% if utc_hero.hero_align == 'Left' %}
-		<div class="utc-hero-block lg:grid lg:grid-rows-utcherocenter lg:grid-cols-utcherocenter lg:gap-y-4 lg:grid-flow-row lg:mb-4 text-center">
-			{% if utc_hero.hero_image %}
-				<div class="lg:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-4 lg:m-auto col-span-1 z-30 {{ utc_zoom }} shadow-utcdark relative">
-					{{ utc_hero.hero_image }} 
-				</div>
-			{% endif %}
-				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-5 lg:my-auto lg:ml-14 p-4 z-30 relative">
-	{% else %}
-		<div class="utc-hero-block lg:grid lg:grid-rows-utcherocenter lg:grid-cols-utcherocenter lg:gap-y-6 grid-flow-row lg:mb-4 text-center">
-			{% if utc_hero.hero_image %}
-				<div class="lg:col-start-3 lg:col-end-5 lg:row-start-2 lg:row-end-4 lg:m-auto z-30 {{ utc_zoom }} shadow-utcdark relative">
-					{{ utc_hero.hero_image }}
-				</div>
-			{% endif %}
-				<div class="lg:col-start-2 lg:col-end-2 lg:row-start-1 lg:row-end-5 lg:mr-14 lg:my-auto py-4 lg:px-6 col-span-1 z-30 relative">
-	{% endif %}
-					{% block herocontent %}
-						{{ parent() }}
-					{% endblock %}
-				</div>
+	<div {{ attributes.addClass(classes) }}>	 
 		{% if utc_hero.hero_align == 'Left' %}
-			<div class="lg:max-w-full lg:ml-0 absolute top-0 left-0 lg:static md:col-start-2 md:col-end-5 md:row-start-1 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10" style="background-image: url({{ utc_hero.hero_bg }})">
+			<div class="utc-hero-block lg:grid lg:grid-rows-utcherocenter lg:grid-cols-utcherocenter lg:gap-y-4 lg:grid-flow-row lg:mb-4 text-center">
+				{% if utc_hero.hero_image %}
+					<div class="lg:col-start-1 lg:col-end-3 lg:row-start-2 lg:row-end-4 lg:m-auto col-span-1 z-30 {{ utc_zoom }} shadow-utcdark relative">
+						{{ utc_hero.hero_image }} 
+					</div>
+				{% endif %}
+					<div class="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-5 lg:my-auto lg:ml-14 p-4 z-30 relative">
 		{% else %}
-			<div class="lg:max-w-full lg:ml-0 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-4 md:row-start-1 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10" style="background-image: url({{ utc_hero.hero_bg }})">
+			<div class="utc-hero-block lg:grid lg:grid-rows-utcherocenter lg:grid-cols-utcherocenter lg:gap-y-6 grid-flow-row lg:mb-4 text-center">
+				{% if utc_hero.hero_image %}
+					<div class="lg:col-start-3 lg:col-end-5 lg:row-start-2 lg:row-end-4 lg:m-auto z-30 {{ utc_zoom }} shadow-utcdark relative">
+						{{ utc_hero.hero_image }}
+					</div>
+				{% endif %}
+					<div class="lg:col-start-2 lg:col-end-2 lg:row-start-1 lg:row-end-5 lg:mr-14 lg:my-auto py-4 lg:px-6 col-span-1 z-30 relative">
 		{% endif %}
-				<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
+						{% block herocontent %}
+							{{ parent() }}
+						{% endblock %}
+					</div>
+			{% if utc_hero.hero_align == 'Left' %}
+				<div class="lg:max-w-full lg:ml-0 absolute top-0 left-0 lg:static md:col-start-2 md:col-end-5 md:row-start-1 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10" style="background-image: url({{ utc_hero.hero_bg }})">
+			{% else %}
+				<div class="lg:max-w-full lg:ml-0 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-4 md:row-start-1 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10" style="background-image: url({{ utc_hero.hero_bg }})">
+			{% endif %}
+					<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
+				</div>
 			</div>
-		</div>
-	{% endblock %}
+	</div>
+{% endblock %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-reverse.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-reverse.html.twig
@@ -11,7 +11,12 @@
  * This template pulls in the variables to add to the hero. 
  * References the block--utc-hero--full.html.twig.
 #}
-
+{%
+  set classes = [
+	'block--utc-image-hero',
+	'block--utc-image-hero-full-reverse',
+  ]
+%}
 {% block content %}
 	{{ attach_library('utccloud/utc-hero-image') }}
 	{% set rendered_content = content|render %}
@@ -55,36 +60,37 @@
 		{% set bg1_opacity = 'opacity-20' %}
     	{% set bg2_opacity = 'opacity-20' %}
 	{% endif %}
-		 
-	{% if utc_hero.hero_align == 'Left' %}
-		<div class="utc-hero-block lg:grid lg:grid-rows-utcheroreverse lg:grid-cols-utchero lg:gap-y-4 lg:grid-flow-row lg:mb-4 text-center shadow-utc relative">
-			{% if utc_hero.hero_image %}
-				<div class="lg:col-start-2 lg:col-end-3 lg:row-start-1 lg:row-end-4 lg:m-auto col-span-1 z-30 {{ utc_zoom }} shadow-utcdark relative">
-					{{ utc_hero.hero_image }} 
+	<div {{ attributes.addClass(classes) }}>
+		{% if utc_hero.hero_align == 'Left' %}
+			<div class="utc-hero-block lg:grid lg:grid-rows-utcheroreverse lg:grid-cols-utchero lg:gap-y-4 lg:grid-flow-row lg:mb-4 text-center shadow-utc relative">
+				{% if utc_hero.hero_image %}
+					<div class="lg:col-start-2 lg:col-end-3 lg:row-start-1 lg:row-end-4 lg:m-auto col-span-1 z-30 {{ utc_zoom }} shadow-utcdark relative">
+						{{ utc_hero.hero_image }} 
+					</div>
+				{% endif %}
+					<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-5 lg:my-auto lg:ml-8 p-4 z-30">
+		{% else %}
+			<div class="utc-hero-block lg:grid lg:grid-rows-utcheroreverse lg:grid-cols-utcheroright lg:gap-y-6 grid-flow-row lg:mb-4 text-center">
+				{% if utc_hero.hero_image %}
+					<div class="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:m-auto z-30 {{ utc_zoom }} shadow-utcdark relative">
+						{{ utc_hero.hero_image }}
+					</div>
+				{% endif %}
+					<div class="lg:col-start-2 lg:col-end-2 lg:row-start-2 lg:row-end-5 lg:mr-8 lg:my-auto py-4 lg:px-6 col-span-1 z-30 relative">
+		{% endif %}
+						{% block herocontent %}
+							{{ parent() }}
+						{% endblock %}
+					</div>
+		{% if utc_hero.hero_align == 'Left' %}			
+				<div class="lg:max-w-95p lg:ml-4 lg:max-w-full lg:md-0 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-5 md:row-start-2 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 " style="background-image: url({{ utc_hero.hero_bg }})">
+					<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
 				</div>
-			{% endif %}
-				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-5 lg:my-auto lg:ml-8 p-4 z-30">
-	{% else %}
-		<div class="utc-hero-block lg:grid lg:grid-rows-utcheroreverse lg:grid-cols-utcheroright lg:gap-y-6 grid-flow-row lg:mb-4 text-center">
-			{% if utc_hero.hero_image %}
-				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:m-auto z-30 {{ utc_zoom }} shadow-utcdark relative">
-					{{ utc_hero.hero_image }}
+		{% else %}
+				<div class="lg:max-w-95p lg:mr-4 lg:max-w-full lg:md-0 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-5 md:row-start-2 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 " style="background-image: url({{ utc_hero.hero_bg }})">
+					<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
 				</div>
-			{% endif %}
-				<div class="lg:col-start-2 lg:col-end-2 lg:row-start-2 lg:row-end-5 lg:mr-8 lg:my-auto py-4 lg:px-6 col-span-1 z-30 relative">
-	{% endif %}
-					{% block herocontent %}
-						{{ parent() }}
-					{% endblock %}
-				</div>
-	{% if utc_hero.hero_align == 'Left' %}			
-			<div class="lg:max-w-95p lg:ml-4 lg:max-w-full lg:md-0 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-5 md:row-start-2 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 " style="background-image: url({{ utc_hero.hero_bg }})">
-				<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
+		{% endif %}
 			</div>
-	{% else %}
-			<div class="lg:max-w-95p lg:mr-4 lg:max-w-full lg:md-0 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-5 md:row-start-2 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 " style="background-image: url({{ utc_hero.hero_bg }})">
-				<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
-			</div>
-	{% endif %}
-		</div>
-	{% endblock %}
+	</div>
+{% endblock %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
@@ -5,7 +5,12 @@
  * Implements a hero block using an image with zoom effect available.
  *
 #}
-
+{%
+  set classes = [
+	'block--utc-image-hero',
+	'block--utc-image-hero-full',
+  ]
+%}
 {% block content %}
 	{{ attach_library('utccloud/utc-hero-image') }}
 	{% set rendered_content = content|render %}
@@ -50,58 +55,60 @@
     	{% set bg2_opacity = 'opacity-20' %}
 	{% endif %}
 	{# image on left #}	 
-	{% if utc_hero.hero_align == 'Left' %}
-		<div class="utc-hero-block lg:grid lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-4 lg:grid-flow-row lg:mb-4 text-center">
-			{% if utc_hero.hero_image %}
-				<div class="lg:col-start-2 lg:col-end-3 lg:row-start-2 lg:row-end-6 lg:m-auto col-span-1 z-30 {{ utc_zoom }} relative shadow-utcdark ">
-					{{ utc_hero.hero_image }} 
-				</div>
-			{% endif %}
-				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:my-auto lg:ml-8 px-4 py-8 relative z-30">
-	{% else %}
-	{# image on right #}	
-		<div class="utc-hero-block lg:grid lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-6 grid-flow-row lg:mb-4 text-center">
-			{% if utc_hero.hero_image %}
-				<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto z-30 {{ utc_zoom }} relative shadow-utcdark ">
-					{{ utc_hero.hero_image }}
-				</div>
-			{% endif %}
-				<div class="lg:col-start-2 lg:col-end-2 lg:row-start-1 lg:row-end-4 lg:mr-8 lg:my-auto py-4 lg:px-6 col-span-1 z-30 relative">
-	{% endif %}
-				{% block herocontent %}
-					{% block herotagtitle %}
-					{% if utc_hero.hero_tag %}
-						<p class="text-left font-semibold tracking-wide uppercase text-lg mb-0 mt-4 {{ tag_color }}">
-							{{ utc_hero.hero_tag }}
-						</p>
-						<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20 ml-0" />
-					{% endif %}
-					{% if utc_hero.hero_title %}
-						<h2 class="text-left mb-2 {{ title_color }}">
-							{{ utc_hero.hero_title }}
-						</h2>
-					{% endif %}
-					{% endblock herotagtitle %}
-					{% block herotextbutton %}
-						{% if utc_hero.hero_text %}
-							<p class="text-left text-lg {{ body_color }}">
-								{{ utc_hero.hero_text}}
-							</p>
-						{% endif %}
-						{% if utc_hero.hero_button_url %}
-							<p class="my-8 text-right">
-								<a href="{{ utc_hero.hero_button_url}}"  class="diagonal {{ btn_class }}" aria-label="Read the release">
-									{{ utc_hero.hero_button_text }} <i class="fas fa-angle-right font-semibold ml-1"></i>
-								</a>
-							</p>
-						{% endif %}
-					{% endblock herotextbutton %}
-				{% endblock herocontent %}
-				</div>
-				{% block herobackground %}
-					<div class="lg:max-w-full lg:ml-0 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-4" style="background-image: url({{ utc_hero.hero_bg }})">
-						<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
+	<div {{ attributes.addClass(classes) }}>
+		{% if utc_hero.hero_align == 'Left' %}
+			<div class="utc-hero-block lg:grid lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-4 lg:grid-flow-row lg:mb-4 text-center">
+				{% if utc_hero.hero_image %}
+					<div class="lg:col-start-2 lg:col-end-3 lg:row-start-2 lg:row-end-6 lg:m-auto col-span-1 z-30 {{ utc_zoom }} relative shadow-utcdark ">
+						{{ utc_hero.hero_image }} 
 					</div>
-				{% endblock herobackground %}
-		</div>
+				{% endif %}
+					<div class="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:my-auto lg:ml-8 px-4 py-8 relative z-30">
+		{% else %}
+		{# image on right #}	
+			<div class="utc-hero-block lg:grid lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-6 grid-flow-row lg:mb-4 text-center">
+				{% if utc_hero.hero_image %}
+					<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto z-30 {{ utc_zoom }} relative shadow-utcdark ">
+						{{ utc_hero.hero_image }}
+					</div>
+				{% endif %}
+					<div class="lg:col-start-2 lg:col-end-2 lg:row-start-1 lg:row-end-4 lg:mr-8 lg:my-auto py-4 lg:px-6 col-span-1 z-30 relative">
+		{% endif %}
+					{% block herocontent %}
+						{% block herotagtitle %}
+						{% if utc_hero.hero_tag %}
+							<p class="text-left font-semibold tracking-wide uppercase text-lg mb-0 mt-4 {{ tag_color }}">
+								{{ utc_hero.hero_tag }}
+							</p>
+							<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20 ml-0" />
+						{% endif %}
+						{% if utc_hero.hero_title %}
+							<h2 class="text-left mb-2 {{ title_color }}">
+								{{ utc_hero.hero_title }}
+							</h2>
+						{% endif %}
+						{% endblock herotagtitle %}
+						{% block herotextbutton %}
+							{% if utc_hero.hero_text %}
+								<p class="text-left text-lg {{ body_color }}">
+									{{ utc_hero.hero_text}}
+								</p>
+							{% endif %}
+							{% if utc_hero.hero_button_url %}
+								<p class="my-8 text-right">
+									<a href="{{ utc_hero.hero_button_url}}"  class="diagonal {{ btn_class }}" aria-label="Read the release">
+										{{ utc_hero.hero_button_text }} <i class="fas fa-angle-right font-semibold ml-1"></i>
+									</a>
+								</p>
+							{% endif %}
+						{% endblock herotextbutton %}
+					{% endblock herocontent %}
+					</div>
+					{% block herobackground %}
+						<div class="lg:max-w-full lg:ml-0 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-4" style="background-image: url({{ utc_hero.hero_bg }})">
+							<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
+						</div>
+					{% endblock herobackground %}
+			</div>
+	</div>
 {% endblock %}


### PR DESCRIPTION
Fixes issue #516 and utccloud https://github.com/UTCWeb/utccloud/issues/2361. These classes added to the image hero ymls in particle--in conjuction with the utc-image-hero.js in utccloud repo--fix the image-hero-above-renders-video-hero-below-useless issue. You can't tell in the image provided, but the first hero is an image hero while the second one is a video hero.

![Screen Shot 2023-02-02 at 5 12 47 PM](https://user-images.githubusercontent.com/82905787/216463088-17dd979f-ce12-4eba-be4f-5ddf0fc06cd3.png)
