### PR TITLE
UTC-510: Mobilize hover images into cards+ more.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-reverse.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-reverse.html.twig
@@ -83,11 +83,11 @@
 						{% endblock %}
 					</div>
 		{% if utc_hero.hero_align == 'Left' %}			
-				<div class="lg:max-w-95p lg:ml-4 lg:max-w-full lg:md-0 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-5 md:row-start-2 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 " style="background-image: url({{ utc_hero.hero_bg }})">
+				<div class="lg:max-w-full lg:max-w-full lg:md-0 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-5 md:row-start-2 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 " style="background-image: url({{ utc_hero.hero_bg }})">
 					<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
 				</div>
 		{% else %}
-				<div class="lg:max-w-95p lg:mr-4 lg:max-w-full lg:md-0 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-5 md:row-start-2 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 " style="background-image: url({{ utc_hero.hero_bg }})">
+				<div class="lg:max-w-full lg:max-w-full lg:md-0 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-5 md:row-start-2 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 " style="background-image: url({{ utc_hero.hero_bg }})">
 					<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
 				</div>
 		{% endif %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hover-images.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hover-images.html.twig
@@ -14,11 +14,15 @@
 {% block content %}
     {# block fields #}
     {% set hover_image_orientation = content.field_image_orientation|field_value|render %}
-    {% set image_orientation = 'image-output-' ~ hover_image_orientation %}
+    {% set block_image_bw = content.field_convert_to_bw|field_value|render %}
+    {% set block_image_overlay = content.field_overlay_color|field_value|render %}
+    {% set block_hide_titles = content.field_hide_initial_title|field_value|render %}
+    {% set block_larger_titles = content.field_larger_titles|field_value|render %}
+    {% set block_image_orientation = 'image-output-' ~ hover_image_orientation %}
     {% set paragraph_count = content.field_hover_image_block['#items']|length %}
     {% set paragraph_count_css = 'grid-cols-' ~ paragraph_count %}
-
-   <div class="block__content utc-image-hover {{ image_orientation }} mb-0 grid gap-4  {{ paragraph_count_css }} " >
+    
+   <div class="block__content utc-image-hover {{ block_image_orientation }} mb-0 grid {{ paragraph_count_css }} gap-4" >
 
     {% for item in content.field_hover_image_block['#items'] %}
 
@@ -28,12 +32,36 @@
         {% set paragraph_media_id = item.entity.field_hover_image.target_id %}
         {% set paragraph_url = item.entity.field_hover_link.0.url %}
         {% set paragraph_url_title = item.entity.field_hover_link.0.title %}
+       {#  {% set paragraph_image_bw = item.entity.field_convert_to_bw.0.value %}
+        {% set paragraph_image_overlay = item.entity.field_overlay_color.0.value %} #} 
+
+        {% if block_image_bw == "On" %}
+            {% set image_color = 'bw-image' %}
+        {% else %}
+            {% set image_color = 'color-image' %}
+        {% endif %}
+
+        {% if block_image_overlay == "On" %}
+            {% set overlay_status = 'overlay-true' %}
+        {% else %}
+            {% set overlay_status = '' %}
+        {% endif %}
+
+        {% set overlay_color = block_image_overlay ~ '-overlay' %}
+
+        {% if block_hide_titles == "On" %}
+            {% set title_hide_show = 'hidden' %}
+        {% else %}
+            {% set title_hide_show = '' %}
+        {% endif %}
+
         {% set figure_classes  = [
             'utc-hover-image-effect',
             'image-count-' ~ paragraph_count,
         ] | sort | join(' ') | trim %}
+        {# Add zoom class if zoom is checked. #}
 
-            <figure class="{{ figure_classes }}">
+            <figure class="{{ figure_classes }} {{ image_color }} {{ overlay_color }} {{ overlay_status }}">
                 {% if hover_image_orientation == 'horizontal' %}
                     {{ drupal_entity('media', paragraph_media_id, 'utc_hover_image_horizontal') }}
                 {% else %}
@@ -43,19 +71,24 @@
                 {% if paragraph_url_title %}
                      <figcaption class="absolute block left-0 right-0 w-full cursor-pointer">
                         <div class="utc-border-wrapper">
-                            <h2 class="m-0 font-bold capitalize text-utc-new-blue-500 leading-tight">{{ paragraph_title }}</h2>
-                            <p class="text-utc-new-blue-500 leading-tight">{{ paragraph_text }}</p>
-                            <a href="{{ paragraph_url }}" title="Go to {{ paragraph_url_title }}" >{{ paragraph_url_title }}</a>
+                            <div class="hover-inner">
+                                <h2 class="m-0 font-bold capitalize text-utc-new-blue-500 leading-tight">{{ paragraph_title }}</h2>
+                                <p class="text-utc-new-blue-500 leading-tight">{{ paragraph_text }}</p>
+                                <a class="hover-button" href="{{ paragraph_url }}" title="{{ paragraph_url_title }}" ><span>{{ paragraph_url_title }}</span></a>
+                            </div>
                         </div>
                     </figcaption>
                 {% else %}
                     <figcaption class="absolute block left-0 right-0 w-full cursor-default">
                         <div class="utc-border-wrapper">
-                            <h2 class="m-0 font-bold capitalize text-utc-new-blue-500 leading-tight">{{ paragraph_title }}</h2>
-                            <p class="text-utc-new-blue-500 leading-tight">{{ paragraph_text }}</p>
+                            <div class="hover-inner">
+                                <h2 class="m-0 font-bold capitalize text-utc-new-blue-500 leading-tight">{{ paragraph_title }}</h2>
+                                <p class="text-utc-new-blue-500 leading-tight">{{ paragraph_text }}</p>
+                            </div>
                         </div>
                     </figcaption>
                 {% endif %}
+                <div class=" {{ title_hide_show }} {{  block_larger_titles }} image-title text-white font-utcheadings text-center pt-1 pb-2 absolute w-full" style="background:rgba(17,46,82,.8);bottom:12px;transition:var(--utc-transition);">{{ paragraph_title }}</div>
             </figure>
 
         {% endfor %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hover-images.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hover-images.html.twig
@@ -41,7 +41,7 @@
             {% set image_color = 'color-image' %}
         {% endif %}
 
-        {% if block_image_overlay == "On" %}
+        {% if block_image_overlay %}
             {% set overlay_status = 'overlay-true' %}
         {% else %}
             {% set overlay_status = '' %}

--- a/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_hover_images.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_hover_images.css
@@ -13,21 +13,28 @@ figure.utc-hover-image-effect * {
   @apply box-border;
 }
 figure.utc-hover-image-effect {
-  @apply relative float-left overflow-hidden;
+  @apply relative overflow-hidden;
   margin: 10px 1%;
   box-shadow: 5px 5px 10px rgb(0 0 0 / 0.5);
+  z-index: 1;
 }
 figure.utc-hover-image-effect img {
   @apply max-w-full opacity-100 w-full;
   transition: opacity 0.35s;
 }
 /*figcaption, text*/
+figure.utc-hover-image-effect .image-title {
+  z-index: 1;
+}
 figure.utc-hover-image-effect figcaption {
-  @apply p-8 max-h-full;
+  @apply p-4 max-h-full h-full;
 }
 figure.utc-hover-image-effect .utc-border-wrapper {
-  @apply opacity-0 sm:ml-auto sm:mr-auto border-l-4 border-utc-new-gold-500 pl-4;
+  @apply opacity-0 sm:ml-auto sm:mr-auto;
   transition: opacity 0.25s, transform 0.25s;
+} 
+figure.utc-hover-image-effect .hover-inner {
+  @apply border-l-4 border-utc-new-gold-500 pl-4;
 } 
 figure.utc-hover-image-effect h2,
 figure.utc-hover-image-effect p {
@@ -58,6 +65,10 @@ figure.utc-hover-image-effect a {
 figure.utc-hover-image-effect:hover figcaption {
   top: 50%;
   transform: translateY(-50%);
+  display: table!important;
+}
+figure.utc-hover-image-effect:hover .image-title {
+  display:none;
 }
 figure.utc-hover-image-effect:hover img {
   @apply opacity-10;
@@ -66,6 +77,8 @@ figure.utc-hover-image-effect:hover .utc-border-wrapper  {
   @apply opacity-100;
   transform: translate3d(0%, 0%, 0);
   transition-delay: 0.2s;
+  display: table-cell!important;
+  vertical-align: middle;
 }
 figure.utc-hover-image-effect:hover h2 {
   @apply opacity-100;
@@ -81,7 +94,7 @@ figure.utc-hover-image-effect:hover p {
 /****1 image***/
 figure.image-count-1 {
   @apply float-none;
-  margin: 10px;
+  margin:4px;
 }
 figure.image-count-1 figcaption {
   @apply lg:p-20;
@@ -89,7 +102,7 @@ figure.image-count-1 figcaption {
 figure.image-count-1 .utc-border-wrapper {
   @apply lg:pl-6;
 } 
-figure.image-count-1 h2 {
+figure.image-count-1 h2, figure.utc-hover-image-effect .image-title {
   @apply lg:text-4xl;
 }
 figure.image-count-1 p {
@@ -103,7 +116,7 @@ figure.image-count-2 figcaption {
 figure.image-count-2 .utc-border-wrapper {
   @apply lg:pl-4;
 } 
-figure.image-count-2 h2 {
+figure.image-count-2 h2, figure.utc-hover-image-effect .image-title {
   @apply lg:text-2xl;
 }
 
@@ -114,11 +127,11 @@ figure.image-count-3 figcaption {
 figure.image-count-3 .utc-border-wrapper {
   @apply xl:pl-4;
 }
-figure.image-count-3 h2 {
-  @apply md:text-base lg:text-2xl
+figure.image-count-3 h2, figure.utc-hover-image-effect .image-title {
+  @apply text-2xl
 }
 figure.image-count-3 p {
-  @apply pb-0 mb-4 md:m-0 lg:mt-2 md:text-xs lg:text-sm xl:text-base;
+  @apply pb-0 mb-4 lg:mt-2 text-base;
 }
 figure.image-count-3 a {
   @apply md:mt-1 lg:mt-4;
@@ -128,379 +141,245 @@ figure.image-count-3 a {
 figure.image-count-4 figcaption {
   @apply md:p-3 lg:p-4;
 }
-figure.image-count-4 h2 {
+figure.image-count-4 h2, figure.image-count-4 .image-title {
   @apply mb-0 pb-0 md:text-base lg:text-lg;
 }
 figure.image-count-4 p {
-  @apply md:hidden lg:inline-block lg:text-xs mx-0;
+  @apply lg:inline-block mx-0 lg:mt-2;
 }
 
-/****Vertical****/
-.image-output-vertical figure.utc-hover-image-effect figcaption {
-  @apply p-16 lg:p-20;
+figure.utc-hover-image-effect figcaption a.hover-button span {
+  @apply text-center text-white bg-utc-new-blue-500 mx-auto py-1 px-4 font-bold;
+  display:none;
+  background-image: -webkit-linear-gradient(257deg, #fdb736 50%, #112e51 50%);
+  background-image: linear-gradient(-257deg, #fdb736 50%, #112e51 50%);
+  background-position: 100%;
+  background-size: 400%;
+  -webkit-transition: all 750ms ease-in-out;
+  transition: all 750ms ease-in-out;
 }
-.image-output-vertical figure.utc-hover-image-effect .utc-border-wrapper {
-  @apply md:border-l-4 md:border-utc-new-gold-500 md:pl-4 lg:mb-0;
-}
-.image-output-vertical figure.utc-hover-image-effect h2 {
-  @apply text-3xl;
-}
-.image-output-vertical figure.utc-hover-image-effect p {
-  @apply text-lg;
-}
-.image-output-vertical figure.utc-hover-image-effect a {
-  @apply text-lg mt-6;
-}
-.image-output-vertical figure.image-count-3 figcaption {
-  @apply md:p-8;
-}
-.image-output-vertical figure.image-count-3 h2 {
-  @apply md:text-2xl ;
-}
-.image-output-vertical figure.image-count-3  p {
-  @apply md:text-base;
-}
-.image-output-vertical figure.image-count-3  a {
-  @apply md:text-base;
-}
-.image-output-vertical figure.image-count-4 figcaption {
-  @apply md:p-4 lg:p-8 lg:pb-0;
-}
-.image-output-vertical figure.image-count-4 h2 {
-  @apply md:text-lg lg:text-2xl ;
-}
-.image-output-vertical figure.image-count-4 p {
-  @apply md:inline-block md:text-xs lg:text-sm xl:text-base;
-}
-.image-output-vertical figure.image-count-4 a {
-  @apply md:text-xs lg:text-base md:mt-2 lg:mt-6;
-}
-
-/****Internal pages treatment***/
-.themag-layout--twocol-section--3-9 figure.utc-hover-image-effect figcaption,
-.themag-layout--twocol-section--9-3 figure.utc-hover-image-effect figcaption {
-  @apply lg:p-8;
-}
-.themag-layout--twocol-section--3-9 figure.image-count-3 figcaption,
-.themag-layout--twocol-section--9-3 figure.image-count-3 figcaption {
-  @apply lg:p-6;
-}
-
-@media (min-width: 1200px) and (max-width: 1280px){
-  .image-output-horizontal figure.image-count-3 figcaption {
-    @apply lg:p-4;
-  }
-  .image-output-horizontal figure.image-count-4 p {
-    @apply lg:mt-0;
-  }
-  .themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-4 h2, 
-  .themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-4 h2 {
-    @apply text-base;
-  }
-  .themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-4 p,
-  .themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-4 p {
-    @apply text-xs;
-  }
-}
-
-.themag-layout--twocol-section--3-9 figure.image-count-4 figcaption,
-.themag-layout--twocol-section--9-3 figure.image-count-4 figcaption {
-  @apply lg:p-4;
-}
-.themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-3 figcaption,
-.themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-3 figcaption {
-  @apply md:p-8;
-}
-.themag-layout--twocol-section--3-9 .image-output-vertica figure.image-count-4 figcaption,
-.themag-layout--twocol-section--9-3 .image-output-vertica figure.image-count-4 figcaption {
-  @apply xl:p-6;
-}
-.themag-layout--twocol-section--3-9 figure.utc-hover-image-effect .utc-border-wrapper,
-.themag-layout--twocol-section--9-3 figure.utc-hover-image-effect .utc-border-wrapper {
-  @apply lg:pl-2;
-} 
-.themag-layout--twocol-section--3-9 figure.image-count-1,
-.themag-layout--twocol-section--9-3 figure.image-count-1  {
-  @apply mx-0;
-}
-.themag-layout--twocol-section--3-9 figure.image-count-1 figcaption,
-.themag-layout--twocol-section--9-3 figure.image-count-1 figcaption {
-  @apply p-20;
-}
-.themag-layout--twocol-section--3-9 figure.image-count-3 h2,
-.themag-layout--twocol-section--9-3 figure.image-count-3 h2 {
-  @apply lg:pb-0 lg:mb-0 lg:text-base;
-}
-.themag-layout--twocol-section--3-9 figure.image-count-3 p,
-.themag-layout--twocol-section--9-3 figure.image-count-3 p {
-  @apply lg:pb-0 lg:mb-0 lg:mt-0 lg:text-xs xl:mt-2;
-}
-.themag-layout--twocol-section--3-9 .image-output-horizontal figure.image-count-4 .utc-border-wrapper, 
-.themag-layout--twocol-section--9-3 .image-output-horizontal figure.image-count-4 .utc-border-wrapper {
-  @apply xl:pl-3;
-}
-.themag-layout--twocol-section--3-9 figure.image-count-4 h2,
-.themag-layout--twocol-section--9-3 figure.image-count-4 h2 {
-  @apply lg:text-sm;
-} 
-.themag-layout--twocol-section--3-9 figure.image-count-4 p,
-.themag-layout--twocol-section--9-3 figure.image-count-4 p {
-  @apply lg:hidden xl:inline-block xl:mt-0;
-}
-.themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-1 figcaption,
-.themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-2 figcaption,
-.themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-3 figcaption,
-.themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-1 figcaption,
-.themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-2 figcaption,
-.themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-3 figcaption {
-  @apply p-12 md:p-8 xl:p-12;
-}
-.themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-4 figcaption,
-.themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-4 figcaption {
-  @apply xl:p-8;
-}
-.themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-3 h2,
-.themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-3 h2 {
-  @apply lg:text-lg ;
-}
-.themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-3 p,
-.themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-3 p {
-  @apply md:text-sm lg:text-base mt-2;
-}
-.themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-3 a,
-.themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-3 a  {
-  @apply md:mt-2 md:text-sm lg:mt-0 lg:text-base;
+figure.utc-hover-image-effect figcaption a.hover-button:hover span {
+  background-position: 0;
+  @apply text-utc-new-blue-500;
 }
 
 .themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-4 h2,
 .themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-4 h2 {
   @apply lg:text-lg ;
 }
+
 .themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-4 p,
 .themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-4 p {
-  @apply lg:inline-block xl:text-sm;
+  @apply lg:inline-block text-base;
 }
 
-/*Remove later
-.grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }*/
+/***image & overlay color choices***/
 
+figure.bw-image  img {
+  filter: saturate(0);
+}
+figure.gold-overlay .field--type-image.field__item {
+  background: rgba(253, 183, 54,.8);
+}
+figure.dk-blue-overlay .field--type-image.field__item {
+  background: rgba(17, 46, 81,.8);
+}
+figure.lt-blue-overlay .field--type-image.field__item {
+  background: rgba(231, 234, 238,.1);
+}
+figure.gold-overlay:hover .field--type-image.field__item,
+figure.dk-blue-overlay:hover .field--type-image.field__item,
+figure.lt-blue-overlay :hover .field--type-image.field__item {
+  background: transparent;
+}
+figure.gold-overlay img,
+figure.dk-blue-overlay img,
+figure.lt-blue-overlay img
+{
+  opacity: .4; 
+}
+figure.overlay-true .image-title {
+  font-weight: bold;
+  text-shadow: unset!important;
+  bottom: 18px!important;
+}
+figure.gold-overlay .image-title {
+  background: transparent!important;
+  color: #112e51!important;
+}
+figure.dk-blue-overlay .image-title,
+figure.lt-blue-overlay .image-title {
+  background: transparent!important;
+  color: #fff!important;
+}
+figure.lt-blue-overlay .image-title {
+  color: #112e51!important;
+}
+.overlay-true .image-title {@apply px-4 leading-5;}
+.image-count-1 .image-title {
+  font-size:1.5rem;
+  bottom: 36px!important
+}
+.image-count-2 .image-title {
+  font-size:1.75rem
+}
+.image-count-3 .image-title {
+  font-size:1.5rem
+}
+.image-count-4 .image-title {
+  font-size:1.25rem;
+  bottom: 0!important;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  line-height: 100%;
+  height: 100%;
+}
 
-/*Additional reponsive styles*/
+.image-count-1 .larger.image-title {
+  font-size:2.25rem;
+}
+.image-count-2 .larger.image-title {
+  font-size:2rem
+}
+.image-count-3 .larger.image-title {
+  font-size:1.75rem
+}
+.image-count-4 .larger.image-title {
+  font-size:1.5rem;
+}
 
-/*The side menu shows at 991px, affecting the layout 3-9 col layout, but we don't have a breakpoint set there. 
-At some point we may want to show the side menu at 1024px, not 991px, showing the mobile dropdown menu at 991px.*/
+/**fail safe styling of grid-cols-#
+.utc-image-hover.grid-cols-2	{ grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.utc-image-hover.grid-cols-3	{ grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.utc-image-hover.grid-cols-4	{ grid-template-columns: repeat(4, minmax(0, 1fr)); } **/
 
-@media (min-width: 991px) and (max-width: 1023px) {
-  /***begin horizontal***/
-  .themag-layout--twocol-section--3-9 .image-output-horizontal figure.image-count-2 figcaption,
-  .themag-layout--twocol-section--9-3 .image-output-horizontal figure.image-count-2 figcaption {
-    @apply p-5;
-  }
-  .themag-layout--twocol-section--3-9 .image-output-horizontal figure.image-count-2 h2,
-  .themag-layout--twocol-section--9-3 .image-output-horizontal figure.image-count-2 h2 {
-    @apply text-base;
-  }
-  .themag-layout--twocol-section--3-9 .image-output-horizontal figure.image-count-2 p,
-  .themag-layout--twocol-section--3-9 .image-output-horizontal figure.image-count-2 a,
-  .themag-layout--twocol-section--9-3 .image-output-horizontal figure.image-count-2 p,
-  .themag-layout--twocol-section--9-3 .image-output-horizontal figure.image-count-2 a {
-    @apply text-xs;
-  }  
-  .themag-layout--twocol-section--3-9 .image-output-horizontal figure.image-count-2 p,
-  .themag-layout--twocol-section--9-3 .image-output-horizontal figure.image-count-2 p {
-    @apply my-0;
-  }
-  .themag-layout--twocol-section--3-9 .image-output-horizontal figure.image-count-3 p,
-  .themag-layout--twocol-section--9-3 .image-output-horizontal figure.image-count-3 p,
-  .themag-layout--twocol-section--3-9 .image-output-horizontal figure.image-count-4 p,
-  .themag-layout--twocol-section--9-3 .image-output-horizontal figure.image-count-4 p {
+@media (min-width: 992px) and (max-width: 1280px) {
+  .themag-layout--twocol-section--3-9 figure.image-count-4 p,
+  .themag-layout--twocol-section--9-3 figure.image-count-4 p {
     @apply hidden;
   }
-  .themag-layout--twocol-section--3-9 .image-output-horizontal figure.image-count-3 a,
-  .themag-layout--twocol-section--9-3 .image-output-horizontal figure.image-count-3 a {
-    @apply text-xs;
-  }
-  .themag-layout--twocol-section--3-9 .image-output-horizontal figure.image-count-3 .utc-border-wrapper,
-  .themag-layout--twocol-section--9-3 .image-output-horizontal figure.image-count-3 .utc-border-wrapper {
-    @apply pl-2;
-  }
-  .themag-layout--twocol-section--3-9 .image-output-horizontal figure.image-count-4 h2,
-  .themag-layout--twocol-section--3-9 .image-output-horizontal figure.image-count-4 a,
-  .themag-layout--twocol-section--9-3 .image-output-horizontal figure.image-count-4 h2,
-  .themag-layout--twocol-section--9-3 .image-output-horizontal figure.image-count-4 a {
-    @apply text-xs mt-1;
-  }
-  .themag-layout--twocol-section--3-9 .image-output-horizontal figure.image-count-4 a,
-  .themag-layout--twocol-section--9-3 .image-output-horizontal figure.image-count-4 a{
-    @apply py-1 px-2;
-  }
+  
+}
 
-  /***begin vertical***/
-  .themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-2 h2,
-  .themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-2 h2 {
-    @apply text-2xl;
+/****Particle Issue 510 Solution: Better mobile experience****/
+@media (max-width:991px) {
+  figure.utc-hover-image-effect img {
+    filter: unset;
+    cursor: none;
+    opacity: 1!important;
   }
-  .themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-2 p,
-  .themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-2 p {
-    @apply text-base;
+  figure.utc-hover-image-effect picture:after {
+    display:none!important;
   }
-  .themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-3 figcaption,
-  .themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-3 figcaption {
-    @apply p-4;
-  }
-  .themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-3 h2,
-  .themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-3 h2 {
-    @apply text-lg;
-  }
-  .themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-3 p,
-  .themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-3 p {
-    @apply text-xs mt-0;
-  }
-  .themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-4 p,
-  .themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-4 p {
-    @apply hidden;
-  }
-  .themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-4 .utc-border-wrapper,
-  .themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-4 .utc-border-wrapper {
-    @apply pl-2;
-  }
-  .themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-4 h2,
-  .themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-4 h2 {
-    @apply text-base;
-  }
-  .themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-4 a,
-  .themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-4 a {
-    @apply pl-1 text-xs;
-  }
-}
-@media (min-width: 768px) and (max-width: 1024px) {
-  figure.utc-hover-image-effect a {
-    @apply opacity-0 inline-block relative text-white px-4 py-1 font-bold text-center w-auto h-auto bg-utc-new-blue-500;
-    transform: translate3d(0%, 30%, 0);
-    transition-delay: 0s;
-  }
-  figure.utc-hover-image-effect:hover a {
-    @apply opacity-100;
-    transform: translate3d(0%, 0%, 0);
-    transition-delay: 0.8s;
-  }
-  figure.image-count-1 p {
-    @apply text-xl;
-  }
-  figure.image-count-2 p {
-    @apply text-sm;
-  }
-  figure.image-count-3 .utc-border-wrapper {
-    @apply pl-2;
-  }
-  figure.image-count-3 a {
-    @apply text-xs;
-  }
-  .grid-cols-4 {
-    @apply grid-cols-2;
-  }
-}
-@media (max-width: 767px) {
-  .utc-image-hover {
-    display: block!important;
-    @apply text-center;
+  figure.utc-hover-image-effect figcaption * {
+    opacity:1;
   }
   figure.utc-hover-image-effect {
-    @apply my-8 mx-auto float-none;
-  }
-  figure.input-horizontal {
-    @apply max-w-max;
+    pointer-events: none;
+    display: flex;
+    flex-direction: column;
+}
+  figure.utc-hover-image-effect:hover,
+  figure.utc-hover-image-effect figcaption,
+  figure.utc-hover-image-effect:hover figcaption,
+  figure.utc-hover-image-effect:hover .utc-border-wrapper,
+  figure.utc-hover-image-effect h2, 
+  figure.utc-hover-image-effect:hover h2,
+  figure.utc-hover-image-effect p,
+  figure.utc-hover-image-effect figcaption a.hover-button
+  {
+    top: unset;
+    transform: unset;
+    transition: unset;
+    transition-delay: unset;
   }
   figure.utc-hover-image-effect figcaption {
-    @apply text-left;
+    background: transparent;
+    padding: 1.5rem!important;
+    transition: all .4s ease-in-out;
+    position: relative !important;
+    display: flex!important;
+    height: 100%!important;
+    margin-bottom: 0!important;
+    opacity: 1;
   }
-  figure.utc-hover-image-effect a {
-    @apply opacity-0 inline-block mt-4 relative text-white px-4 py-1 font-bold text-center w-auto h-auto bg-utc-new-blue-500;
-    transform: translate3d(0%, 30%, 0);
-    transition-delay: 0s;
+  figure.utc-hover-image-effect:hover figcaption {
+    display: flex!important;
   }
-  .image-output-vertical figure.utc-hover-image-effect a {
-    @apply py-2;
+  figure.utc-hover-image-effect .utc-border-wrapper {
+    display: flex!important;
+    opacity:1!important;
+    height: 100% !important;
+    position: relative;
+    width:100%;
   }
-  figure.utc-hover-image-effect:hover a {
-    @apply opacity-100;
-    transform: translate3d(0%, 0%, 0);
-    transition-delay: 0.8s;
+  figure.utc-hover-image-effect .hover-inner {
+    display: flex;
+    flex-direction: column;
+    overflow: auto;
+    height:100%;
+    width:100%;
+    justify-content: space-between;
   }
-  .themag-layout--twocol-section--3-9 .image-output-horizontal figure.image-count-4 .utc-border-wrapper, 
-  .themag-layout--twocol-section--9-3 .image-output-horizontal figure.image-count-4 .utc-border-wrapper {
-    @apply border-l-4 border-utc-new-gold-500 pl-4;
+  figure.utc-hover-image-effect figcaption h2 {
+    font-weight:600!important;
+    font-size:1.5rem;
+  }
+  figure.utc-hover-image-effect figcaption p {
+    font-size:.95rem;
+    overflow-x: hidden;
+    margin: 0;
+    margin-top: 6px;
+    margin-bottom: auto!important;
+  }
+  figure.utc-hover-image-effect figcaption a.hover-button {
+    width: fit-content!important;
+    pointer-events: auto;
+    position: relative;
+  }
+  figure.utc-hover-image-effect figcaption a.hover-button span {
+    display:inline-block;
+    font-size: 1rem;
+  }
+  figure.image-count-4 figcaption a.hover-button span {
+    padding-left: 9px;
+    padding-right: 9px;
+    width: 100%;
+  }
+  .image-title, .image-count-4.overlay-true .image-title {
+    display: none;
+  }
+  .utc-image-hover.grid-cols-4	{ grid-template-columns: repeat(2, minmax(0, 1fr))!important; } 
+}
+
+@media screen and (max-width: 768px) {
+  figure.utc-hover-image-effect .utc-border-wrapper {
+    opacity:1!important;
+    height: 100% !important;
+    position: relative;
+  }
+  figure.utc-hover-image-effect figcaption h2 {
+    font-size:1.75rem;
+  }
+  figure.utc-hover-image-effect figcaption p {
+    font-size:1.1rem;
   }
 }
-@media (max-width: 459px) {
-  .themag-layout--twocol-section--3-9 figure.image-count-1 figcaption, 
-  .themag-layout--twocol-section--9-3 figure.image-count-1 figcaption {
-    @apply p-4;
+@media screen and (max-width: 767px) {
+  .utc-image-hover {
+    grid-template-columns: repeat(1, minmax(0, 1fr))!important;
+    gap: 2rem!important;
   }
-  figure.utc-hover-image-effect h2 {
-    @apply text-xl;
+  .utc-image-hover.grid-cols-4	{ grid-template-columns: repeat(1, minmax(0, 1fr))!important; } 
+  figure.utc-hover-image-effect {
+    width: 90%;
+    margin-top: 6px;
+    margin-bottom:6px;
+    margin-left: auto;
+    margin-right: auto;
   }
-  figure.utc-hover-image-effect p {
-    @apply text-lg;
-  }
-  .hover-image-space {
-    @apply mt-0 h-0;
-  }
-}
-@media (max-width: 420px) {
-  figure.image-count-1 figcaption {
-    @apply p-8;
-  }
-  .hover-image-space {
-    @apply mt-10;
-  }
-}
-@media (max-width: 320px) {
-  figure.utc-hover-image-effect p {
-    @apply my-1 text-base;
-  }
-  figure.utc-hover-image-effect a {
-    @apply mt-1;
-  }
-  figure.utc-hover-image-effect figcaption,
-  figure.image-count-1:hover figcaption,
-  figure.image-count-2:hover figcaption {
-    @apply p-4;
-  }
-  figure.image-count-4:hover figcaption {
-    @apply p-8;
-  }
-  figure.utc-hover-image-effect h2 {
-    @apply pb-0;
-  }
-  .image-output-horizontal figure.image-count-4 p {
-    @apply text-sm;
-  }
-}
-@media (max-width: 280px) {
-  figure.utc-hover-image-effect p {
-    @apply text-sm;
-  }
-  figure.image-count-4 p {
-    @apply text-xs;
-  }
-  .image-output-horizontal .hover-image-space {
-    @apply mt-6;
-  }
-  .image-output-vertical figure.utc-hover-image-effect figcaption {
-    @apply p-12;
-  }
-  figure.image-count-4:hover figcaption {
-    @apply p-4;
-  }
-  .themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-1 figcaption, 
-  .themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-2 figcaption, 
-  .themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-3 figcaption, 
-  .themag-layout--twocol-section--3-9 .image-output-vertical figure.image-count-4 figcaption,
-  .themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-1 figcaption, 
-  .themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-2 figcaption, 
-  .themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-3 figcaption,
-  .themag-layout--twocol-section--9-3 .image-output-vertical figure.image-count-4 figcaption {
-    @apply p-8;
+  figure.utc-hover-image-effect .utc-border-wrapper {
+    min-height: 150px;
   }
 }

--- a/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_hover_images.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_hover_images.css
@@ -122,7 +122,7 @@ figure.image-count-2 h2, figure.utc-hover-image-effect .image-title {
 
 /***3 images***/
 figure.image-count-3 figcaption {
-  @apply md:p-4 md:pt-3 lg:p-8;
+  @apply md:p-4 md:pt-3 lg:p-4;
 }
 figure.image-count-3 .utc-border-wrapper {
   @apply xl:pl-4;
@@ -147,6 +147,19 @@ figure.image-count-4 h2, figure.image-count-4 .image-title {
 figure.image-count-4 p {
   @apply lg:inline-block mx-0 lg:mt-2;
 }
+.image-output-horizontal .image-count-4.overlay-true .image-title {
+  bottom: 0!important;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  line-height: 100%;
+  height: 100%;
+}
+.image-output-horizontal .image-count-4.overlay-true:hover .image-title {
+  display: none;
+}
+
+
 
 figure.utc-hover-image-effect figcaption a.hover-button span {
   @apply text-center text-white bg-utc-new-blue-500 mx-auto py-1 px-4 font-bold;
@@ -228,12 +241,6 @@ figure.lt-blue-overlay .image-title {
 }
 .image-count-4 .image-title {
   font-size:1.25rem;
-  bottom: 0!important;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  line-height: 100%;
-  height: 100%;
 }
 
 .image-count-1 .larger.image-title {

--- a/source/default/_patterns/00-protons/legacy/css/global.css
+++ b/source/default/_patterns/00-protons/legacy/css/global.css
@@ -3,6 +3,7 @@
   --utc-transition: all 0.4s ease-in-out;
   --utc-color: color 0.4s ease-in-out;
   --utc-link: color 0.4s ease-in-out;
+  --utc-text-shadow: 3px 4px 7px rgba(81,67,21,0.8);
 }
 html {
   scroll-behavior: smooth;


### PR DESCRIPTION
This pull requests solves several issues, mainly mobility issues regarding the Hover Image #510 . It accomplishes these items:

1. For devices under 992px, the hover images convert to cards.
2. BC CECS requested special treatment for the hover images that required css overrides, this component has been expanded with more options to accommodate these asks without overrides. They include the following:

- Optional initial title on the image to indicate that the image is a "button" of sorts.
- Images can be converted to black and white.
- Images can be converted to duotones with either blue, gold, or light blue.
- Option to enlarge the initial title for sections without columns such as the sidebar menu.

3. A minor width tweak was made on the UTC image hero full-reverse block.

Desktop:

Horizontal
![hover-1-hz](https://user-images.githubusercontent.com/82905787/219145536-dac8aa48-0cdf-4c01-aa2e-cd40f7bf46b5.gif)

Vertical
![hover-1-vt](https://user-images.githubusercontent.com/82905787/219145623-8f600632-6017-4929-bda1-6e7201533b45.gif)

Tablet:
![hover-3](https://user-images.githubusercontent.com/82905787/219145813-e68eb308-ba9f-4143-bc2a-bb81d68ec1a9.gif)

Phone:
![hover-2](https://user-images.githubusercontent.com/82905787/219145852-fa9b72db-e9af-4eea-b789-e62f54a8bbea.gif)

