### PR TITLE
UTC-510: Hide captions to keep image size correct.

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_hover_images.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_hover_images.css
@@ -256,10 +256,10 @@ figure.lt-blue-overlay .image-title {
   font-size:1.5rem;
 }
 
-/**fail safe styling of grid-cols-#
-.utc-image-hover.grid-cols-2	{ grid-template-columns: repeat(2, minmax(0, 1fr)); }
-.utc-image-hover.grid-cols-3	{ grid-template-columns: repeat(3, minmax(0, 1fr)); }
-.utc-image-hover.grid-cols-4	{ grid-template-columns: repeat(4, minmax(0, 1fr)); } **/
+/**Hide captions which adversely affect image height**/
+.utc-image-hover .media-image .field--name-field-description {
+  display: none;
+}
 
 @media (min-width: 992px) and (max-width: 1280px) {
   .themag-layout--twocol-section--3-9 figure.image-count-4 p,


### PR DESCRIPTION
During Clouddev testing, it was discovered that images that have captions adversely affect the image height. Captions need to be hidden for image hovers as users will not know how to fix this, plus images may be on other pages that require the caption to be shown. This only hides them for the Hover Image block.

Before:
![Screenshot 2023-02-16 at 9 10 44 AM](https://user-images.githubusercontent.com/82905787/219389218-020aa0aa-11e0-4ebd-a3d1-5801e54eac05.png)

After:
![Screenshot 2023-02-16 at 9 17 00 AM](https://user-images.githubusercontent.com/82905787/219389322-d9b69a02-6c2e-4213-b618-efd7d0613f10.png)
