### PR TITLE
UTC-525: Add HZ menu & b-bar integration tweaks.

### DIFF
--- a/apps/drupal-default/particle_theme/particle.info.yml
+++ b/apps/drupal-default/particle_theme/particle.info.yml
@@ -16,6 +16,7 @@ regions:
   header_primary_menu: 'Primary menu'
   search: 'Search'
   offcanvas_sidebar: 'Off-Canvas sidebar'
+  top_workbench_menu: 'Top Workbench Menu'
   content_administration: 'Tabs'
   content_header: 'Content Header'
   content: 'Content'

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-center.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-center.html.twig
@@ -43,9 +43,9 @@
 	{% endif %}
 	{# Sets colors for hero content depending on selection #}
 	{% if utc_hero.hero_color == 'Dark Blue' %}
-		{% set title_color = 'lg:text-white' %}
-		{% set body_color = 'lg:text-white' %}
-		{% set tag_color = 'lg:text-white' %}
+		{% set title_color = 'text-white' %}
+		{% set body_color = 'text-white' %}
+		{% set tag_color = 'text-white' %}
 		{% set btn_border_color = "lg:border-white" %}
 		{% set bg_color = 'background-color:#112e51' %}
 		{% set bg1_opacity = '' %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-reverse.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-reverse.html.twig
@@ -72,7 +72,7 @@
 		{% else %}
 			<div class="utc-hero-block lg:grid lg:grid-rows-utcheroreverse lg:grid-cols-utcheroright lg:gap-y-6 grid-flow-row lg:mb-4 text-center">
 				{% if utc_hero.hero_image %}
-					<div class="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:m-auto z-30 {{ utc_zoom }} shadow-utcdark relative">
+					<div class="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:m-auto z-30 {{ utc_zoom }} relative">
 						{{ utc_hero.hero_image }}
 					</div>
 				{% endif %}
@@ -83,11 +83,11 @@
 						{% endblock %}
 					</div>
 		{% if utc_hero.hero_align == 'Left' %}			
-				<div class="lg:max-w-full lg:max-w-full lg:md-0 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-5 md:row-start-2 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 " style="background-image: url({{ utc_hero.hero_bg }})">
+				<div class="lg:max-w-full lg:max-w-full lg:md-0 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-5 md:row-start-2 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 shadow-utcdark" style="background-image: url({{ utc_hero.hero_bg }})">
 					<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
 				</div>
 		{% else %}
-				<div class="lg:max-w-full lg:max-w-full lg:md-0 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-5 md:row-start-2 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 " style="background-image: url({{ utc_hero.hero_bg }})">
+				<div class="lg:max-w-full lg:max-w-full lg:md-0 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-5 md:row-start-2 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 shadow-utcdark" style="background-image: url({{ utc_hero.hero_bg }})">
 					<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
 				</div>
 		{% endif %}

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-reverse.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-reverse.html.twig
@@ -43,9 +43,9 @@
 	{% endif %}
 	{# Sets colors for hero content depending on selection #}
 	{% if utc_hero.hero_color == 'Dark Blue' %}
-		{% set title_color = 'lg:text-white' %}
-		{% set body_color = 'lg:text-white' %}
-		{% set tag_color = 'lg:text-white' %}
+		{% set title_color = 'text-white' %}
+		{% set body_color = 'text-white' %}
+		{% set tag_color = 'text-white' %}
 		{% set btn_border_color = "lg:border-white" %}
 		{% set bg_color = 'background-color:#112e51' %}
 		{% set bg1_opacity = '' %}
@@ -68,7 +68,7 @@
 						{{ utc_hero.hero_image }} 
 					</div>
 				{% endif %}
-					<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-5 lg:my-auto lg:ml-8 p-4 z-30">
+					<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-5 lg:my-auto lg:ml-8 p-4 z-30 relative">
 		{% else %}
 			<div class="utc-hero-block lg:grid lg:grid-rows-utcheroreverse lg:grid-cols-utcheroright lg:gap-y-6 grid-flow-row lg:mb-4 text-center">
 				{% if utc_hero.hero_image %}

--- a/apps/drupal-default/particle_theme/templates/layout/page/page--layout-builder-enabled.html.twig
+++ b/apps/drupal-default/particle_theme/templates/layout/page/page--layout-builder-enabled.html.twig
@@ -7,6 +7,7 @@
    {% include '@themag/base-layout/header/header.html.twig' %}
   {# {% include '@particle/layout/header/custom-header.html.twig' %}  #}
     {{ page.offcanvas_sidebar }}
+    {{ page.top_workbench_menu }}
     {{ page.content_administration }}
     <main role="main" id="main-content" tabindex="-1">
       {{ page.content }}

--- a/source/default/_patterns/00-protons/index.js
+++ b/source/default/_patterns/00-protons/index.js
@@ -44,6 +44,7 @@ import './legacy/css/components/UTC-custom-blocks/_utc_hover_images.css';
 import './legacy/css/components/field/_field--block-content--field-tags.css';
 import './legacy/css/components/UTC-custom-blocks/_utc_hero_video.css';
 import './legacy/css/components/UTC-custom-blocks/_utc_video_component.css';
+import './legacy/css/components/navigation/_top-workbench-menu.css';
 // import "./legacy/css/components/UTC-custom-blocks/";
 // import "./legacy/css/components/field/";
 
@@ -52,6 +53,7 @@ import './legacy/css/components/UTC-custom-blocks/_utc_video_component.css';
 import './legacy/js/utc-sidebar-menu.js';
 import './legacy/js/slick-custom-arrows.js';
 import './legacy/js/utc-quoteblock.js';
+import './legacy/js/top-workbench-menu.js';
 // import './legacy/js/ckeditor-jquery.js';
 
 // Export global variables.

--- a/source/default/_patterns/00-protons/legacy/css/components/header/_utc_custom_header.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/header/_utc_custom_header.css
@@ -67,8 +67,9 @@ ul.sf-menu.menu>li.sf-depth-1 {
     animation-iteration-count: 1;
     animation-fill-mode: forwards;
 }
-ul.sf-menu li:hover > ul, ul.sf-menu li.sfHover > ul, ul.sf-menu ul {
+ul.sf-menu li:hover > ul, ul.sf-menu li.sfHover > ul {
     left:unset!important;
+    top:105%!important;
 }
 ul.sf-menu ul {
     @apply w-9 left-auto right-0 bg-white min-w-9 float-right;
@@ -94,7 +95,9 @@ ul.sf-menu  > li:not(:last-child) {
 ul.sf-menu > li a  {
     @apply border-0 border-r border-gray-500;
 }
-ul.sf-menu > li > a:after, ul.sf-menu span.nolink:after, ul.sf-menu>li.sfHover>a.is-active {
+ul.sf-menu > li > a:after, 
+ul.sf-menu span.nolink:after, 
+ul.sf-menu>li.sfHover>a.is-active:after {
     @apply block h-0;
     margin-top: 5px;
     content: "";
@@ -201,21 +204,25 @@ ul.sf-menu span.sf-sub-indicator {
     left:12px!important;
     top:9px!important;
     margin-top:-10px;
+    width: 100%!important;
+    padding-right:24px;
 }
 .menus-wrapper {
-    /***This ensures that the looooong mobile is completely scrollable***/
+    /***This ensures that the looooong mobile is completely scrollable and shadows show***/
     display:block;
     padding-bottom:60px;
+    height: auto;
+    padding-left: 6px
 }
 .menus-wrapper ul, #superfish-secondary-menu--2-accordion {
     width:12.8rem!important;
     float:right;
-    box-shadow: -3px 3px 5px rgb(0 0 0/15%)!important;
 }
 #block-utcbrandbarmenu-offcanvas, 
 #block-utcsecondarymenu-offcanvas, 
 #block-utclibbrandbarmenu-offcanvas {
     @apply overflow-hidden;
+    box-shadow: -1px 1px 2px 2px rgb(0 0 0 / 15%);
 }
 /****overrides for mobile DOM issue on brand bar rollout 3/21/22**/
 /***hide the toggle button***/
@@ -265,10 +272,14 @@ ul.sf-menu span.sf-sub-indicator {
     @apply outline-none;
     transition: var(--utc-transition);
 }
-.header__toggleable-button:hover {
-    transform: scale(1.5);
+svg#mainMenuIcon {
+    transition: all .4s ease-in-out;
 }
-
+.sidr-open svg#mainMenuIcon {
+    rotate: 90deg;
+    margin-top: -5px;
+    transition: all .4s ease-in-out;
+}
 /****format search box****/
 .region-search .block--search form input[type=submit] {
     @apply invisible;
@@ -301,9 +312,7 @@ a.close-search-btn, a.close-search-btn:hover, a.close-search-btn:active {border:
     transition: var(--utc-transition); 
     outline:none!important;
 }
-.sidr-open .js-toggle-offcanvas-sidebar {
-    transform: scale(1.5);
-}
+
 .sidr-open .js-toggle-offcanvas-sidebar .fas:before {
     /***fontawesome fa-times content***/
     /*content: "\f00d";*/
@@ -413,15 +422,16 @@ div.site-alert div.text {
 }
 @media screen and (max-width: 768px) {
     .header--custom-header .header__main {
-        @apply mr-28;
+        @apply mr-28 h-full;
     }
-
+    .region-search.active {
+        min-height:100px;
+    }
     .sidr {
-        top: 62px;
+        top: 60px;
     }
     .menus-wrapper ul, #superfish-secondary-menu--2-accordion {
-        /*allow for left shadow to show*/
-        width:12.9rem!important;
+        width: 100%!important
     }
     #superfish-secondary-menu--2-accordion {
         margin-right: -1px!important;
@@ -441,32 +451,32 @@ div.site-alert div.text {
         opacity:100%!important;
     }
     /***end special alert implementation***/
-
-    .top-bar-wrapper,.header--custom-header .header__container-wrapper--header__main {
-         height:unset;
-     }
+    .header-container, .header--custom-header .header__container-wrapper--header__main,.top-bar-wrapper {
+        height: 60px;
+    }
     .bottom-bar-wrapper {
         @apply hidden;
     }
     .toggle-offcanvas-sidebar {
         @apply block;
+        font-size:2rem;
     }
     .toggle-offcanvas-sidebar:focus,
     .toggle-offcanvas-sidebar:hover {
         outline:none!important;
     }
     .sidr.right {
-        width:13rem!important;
+        width:15rem!important;
     }
     .d-flex { 
-        @apply border-r border-gray-500 pr-8;
+        @apply border-r border-gray-500 pr-4;
     }
 
     .sidr ul.sf-menu.sf-accordion li.sf-expanded:last-child>ul >li:last-child {
         @apply mb-4;
     }
     .region-search .close-search-btn.top-0 {
-        top:-1rem!important;
+        top:0!important;
         right:1rem!important;
     }
     .region-search .block--search form input[type=submit] {
@@ -475,7 +485,7 @@ div.site-alert div.text {
     .sidr ul.sf-menu.menu.sf-secondary-menu li {
         @apply bg-white pt-0 pb-0;
     }
-    .sidr ul.sf-menu.menu.sf-secondary-menu li:hover {
+    .sidr ul.sf-menu.menu.sf-secondary-menu.sf-expanded li:hover {
         @apply bg-utc-new-blue-100;
     }
     .sidr ul.sf-menu.menu.sf-secondary-menu li:first-child ul li:last-child {
@@ -515,6 +525,9 @@ div.site-alert div.text {
     }
     .header__container {
        padding-top:1rem!important;padding-bottom:1rem!important;
+    }
+    .menus-wrapper {
+        padding-left:0;
     }
 }
 

--- a/source/default/_patterns/00-protons/legacy/css/components/navigation/_top-workbench-menu.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/navigation/_top-workbench-menu.css
@@ -1,0 +1,358 @@
+.top-workbench-menu-present .header-container {
+  z-index: 101;
+}
+.region-top-workbench-menu .block {
+  display: flex !important;
+  flex-direction: row;
+  justify-content: start;
+  background: #112e51;
+  color: #fff;
+  height: 50px;
+  z-index: 100;
+  position: relative;
+  box-shadow: 1px 1px 3px 3px rgb(0 0 0 / 20%);
+  padding-right: 6.83335rem;
+}
+.region-top-workbench-menu .block * {
+  font-family: "Roboto", sans-serif;
+}
+.region-top-workbench-menu .block__content {
+  width: 100%;
+}
+.region-top-workbench-menu h2.block__title {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  background: #fdb856;
+  position: relative;
+}
+.region-top-workbench-menu .block__title .title-text {
+  font-family: "Oswald", sans-serif;
+  color: #112e51;
+  font-size: .95rem;
+  letter-spacing: .025rem;
+  white-space: nowrap;
+}
+.region-top-workbench-menu .block__title a .title-text {
+  display: inline-block;
+  color: #112e51;
+  overflow: hidden;
+  background: linear-gradient(to right, #fff, #fff 50%, #112e51 50%);
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-size: 200% 100%;
+  background-position: 100%;
+  transition: background-position 275ms ease;
+  text-decoration: none;
+}
+.region-top-workbench-menu .block__title a:hover .title-text {
+  background-position: 0 100%;
+}
+.region-top-workbench-menu h2.block__title:before {
+  display: none;
+}
+.region-top-workbench-menu h2.block__title:after {
+  content: '';
+  position: absolute;
+  right: -50px;
+  top: 0;
+  border-top: 25px solid #fdb736;
+  border-left: 25px solid transparent;
+  border-right: 25px solid transparent;
+  transform: rotate(-90deg);
+  height: 50px;
+}
+ul.sf-menu.menu.top-workbench-menu {
+  justify-content: end;
+  height: 50px;
+  box-shadow: none;
+}
+ul.sf-menu.top-workbench-menu > li > a {
+  position: relative;
+  display: inline-block;
+  font-family: "Roboto", sans-serif;
+  color: #fff;
+  overflow: hidden;
+  background: linear-gradient(to right, #fdb736, #fdb736 50%, #fff 50%);
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-size: 200% 100%;
+  background-position: 100%;
+  transition: background-position 275ms ease;
+  text-decoration: none;
+  border-color: #fdb736;
+}
+ul.sf-menu.top-workbench-menu > li > a:hover {
+  background-position: 0 100%;
+}
+
+ul.sf-menu.top-workbench-menu > li:last-child > a {
+  border: none;
+}
+ul.sf-menu.top-workbench-menu > li > a.is-active,
+ul.sf-menu.top-workbench-menu > li > a:active {
+  background-position: 0 100%;
+}
+ul.sf-menu.top-workbench-menu > li > a:after {
+  display: none;
+}
+ul.sf-menu.top-workbench-menu span.sf-sub-indicator:after {
+  border-top: 4px solid #fff;
+}
+ul.sf-menu.top-workbench-menu a:hover span.sf-sub-indicator:after {
+  border-top: 4px solid #fdb736;
+}
+ul.sf-menu.top-workbench-menu ul {
+  background: #e7eaee;
+}
+ul.sf-menu.top-workbench-menu ul li {
+  border-bottom: 1px solid #fff;
+  word-wrap: normal;
+  white-space: normal;
+}
+ul.sf-menu.top-workbench-menu ul li:last-child {
+  border-bottom: 3px solid #fdb736;
+}
+ul.sf-menu.top-workbench-menu ul li a {
+  background-color: #e7eaee;
+}
+ul.sf-menu.top-workbench-menu ul li a:hover {
+  background: #fff;
+  color: #112e51 !important
+}
+ul.sf-menu.top-workbench-menu li.sfHover>ul, ul.sf-menu.top-workbench-menu li:hover>ul {
+  top: 100%!important;
+}
+@media (max-width:991px) {
+  .region-top-workbench-menu .block {
+    display: block !important;
+    height: 100px;
+    padding-right: 0 !important;
+  }
+  .region-top-workbench-menu h2.block__title {
+    display: block;
+    height: 50px;
+  }
+  .region-top-workbench-menu .block__content {
+    display: flex;
+    justify-content: center;
+  }
+}
+@media (max-width: 768px) {
+  
+  .top-workbench-menu-present .header-container {
+    z-index: 1001;
+  }
+  .top-workbench-menu-present .region--offcanvas-sidebar {
+    z-index: 1000;
+    position: relative;
+  }
+  .region-top-workbench-menu {
+    width: 100%;
+    background: #112e51;
+    z-index: 500;
+    position: relative;
+    box-shadow: -1px 1px 3px 3px rgb(0 0 0 / 20%);
+  }
+  .region-top-workbench-menu .block {
+    display: flex !important;
+    height: 50px;
+    position: relative;
+    box-shadow:none;
+  }
+  .region-top-workbench-menu h2.block__title {
+    width: unset;
+    height: 50px;
+    display: flex;
+    z-index: 501;
+  }
+  .region-top-workbench-menu h2.block__title:after {
+    display: none;
+  }
+  .region-top-workbench-menu .block__content {
+    background: transparent;
+    justify-content: start;
+    width: 36px;
+  }
+  .region-top-workbench-menu .sf-accordion-toggler {
+    padding-left: 12px;
+    padding-right: 24px;
+    display: block;
+    position: absolute;
+  }
+  .region-top-workbench-menu .sf-accordion-toggle {
+    padding-left: 12px;
+  }
+  .region-top-workbench-menu .sf-accordion-toggle .region-top-workbench-menu .sf-accordion-toggle a {
+    border-top: 2px solid #fdb736;
+    border-bottom: 2px solid #fdb736;
+    height: 18px;
+    width: 21px;
+    display: flex !important;
+    align-items: center;
+    margin-top: 12px;
+    margin-bottom: 12px;
+  }
+  .region-top-workbench-menu .sf-accordion-toggle a {
+    display: block !important;
+  }
+  .region-top-workbench-menu .sf-accordion-toggle > a span {
+    color: transparent;
+  }
+  .top-workbench-menu-present main {
+    padding-top: 0 !important;
+  }
+  .region-top-workbench-menu .sf-accordion-toggle.sf-style-none {
+    height: 50px;
+    background: #fdb736;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 500;
+    margin-left: -1px;
+  }
+  .region-top-workbench-menu .sf-accordion-toggle.sf-style-none > li:not(:last-child) {
+    border-bottom: 1px solid #e7eaee;
+  }
+  .region-top-workbench-menu .sf-accordion-toggle.sf-style-none span {
+    font-family: 'Oswald', sans-serif;
+    text-transform: uppercase;
+    font-weight: bold;
+    letter-spacing: .05rem;
+    color: #112e51;
+    display: block !important;
+    height: 45px;
+    width: 24px;
+    font-size: 55px;
+    transition: all .4s ease-in-out;
+  }
+  .region-top-workbench-menu .sf-accordion-toggle.sf-style-none .sf-expanded span {
+    rotate: 90deg;
+    margin-top: -5px;
+    transition: all .4s ease-in-out;
+  }
+  ul.sf-menu.menu.top-workbench-menu.sf-horizontal {display:none;}
+
+  ul.sf-menu.top-workbench-menu ul li a {
+    background-color: #fff;
+  }
+  ul.sf-menu.top-workbench-menu ul li a:hover {
+    background-color: #e7eaee;
+  }
+  .region-top-workbench-menu .sf-accordion-toggle a:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    border-top: 25px solid #fdb736;
+    border-left: 25px solid transparent;
+    border-right: 25px solid transparent;
+    transform: rotate(-90deg);
+    height: 50px;
+    margin-left: 23px;
+  }
+  ul.sf-menu.menu.top-workbench-menu {
+    justify-content: start;
+    background: #fff;
+    position: absolute;
+    top: 50px !important;
+    left: -100% !important;
+    float: none;
+    border-bottom: 3px solid #fdb736;
+    transition: all .4s ease-in-out;
+  }
+  ul.sf-menu.menu.top-workbench-menu.sf-expanded {
+    width: 100%;
+    left: 0 !important;
+    box-shadow: 1px 1px 2px 2px rgb(0 0 0 / 20%);
+    height: auto;
+    border-bottom: none;
+  }
+  ul.sf-menu.menu.top-workbench-menu > li.sf-depth-1 {
+    width: 100%;
+    border-bottom: 1px solid rgba(255, 255, 255, .4);
+  }
+  .region-top-workbench-menu ul.sf-menu.menu.sf-expanded {
+    display: flex;
+    flex-direction: column;
+  }
+  ul.sf-menu.top-workbench-menu li a {
+    border: none;
+    color: #112e51 !important;
+  }
+  ul.sf-menu.menu.top-workbench-menu > li.sf-depth-1 {
+    width: 100%;
+    border-bottom: 1px solid #e7eaee;
+    padding-bottom: 0;
+    padding-top: 0;
+    background: #fff;
+  }
+  ul.sf-menu.menu.sf-expanded > li.sf-depth-1 {
+    animation: fadeOut 3s ease;
+    animation-iteration-count: 1;
+    animation-fill-mode: backwards;
+  }
+  ul.sf-menu.menu.sf-expanded > li.sf-depth-1:first-child {
+    box-shadow: inset 0 7px 9px -7px rgba(0, 0, 0, 0.4);
+  }
+  ul.sf-menu.menu.top-workbench-menu > li.sf-depth-1.sf-expanded {
+    background: #e7eaee;
+  }
+  ul.sf-menu.top-workbench-menu ul, ul.sf-menu.top-workbench-menu li.sfHover > ul, ul.sf-menu.top-workbench-menu li:hover > ul {
+    background: #fff;
+    position: relative;
+    margin-left: 12px;
+    top: 0 !important;
+  }
+  ul.sf-menu.top-workbench-menu li.sfHover > ul, ul.sf-menu.top-workbench-menu li:hover > ul {
+    left: unset !important;
+    top: 0 !important;
+    width: 90%!important;
+  }
+  ul.sf-menu.top-workbench-menu li a {
+    font-size: 1rem;
+    color: #112e51 !important;
+    padding-top: 1.25rem;
+    padding-bottom: 1.25rem;
+    width: 100%;
+    background: unset;
+    -webkit-text-fill-color: unset;
+  }
+  ul.sf-menu.top-workbench-menu li a:hover, ul.sf-menu.top-workbench-menu li.sf-expanded a {
+    color: #112e51;
+  }
+  ul.sf-menu.top-workbench-menu span {
+    margin-right: 9px;
+  }
+  .top-workbench-menu {
+    transition: all .4s ease-in-out;
+  }
+  ul.sf-menu.top-workbench-menu span.sf-sub-indicator:after {
+    border-top: 4px solid #112e51 !important;
+    content:"";
+  }
+  ul.sf-menu.top-workbench-menu span.sf-sub-indicator {
+    right: -0.1rem;
+    transition: all .4s ease-in-out;
+  }
+  ul.sf-menu.top-workbench-menu li:active span.sf-sub-indicator, ul.sf-menu.top-workbench-menu li.sf-expanded span.sf-sub-indicator {
+    transform: rotate(0deg);
+  }
+  ul.sf-menu.top-workbench-menu ul li:last-child {
+    border-bottom: none;
+    margin-bottom: 12px;
+  }
+  ul.sf-menu.top-workbench-menu ul li:last-child:hover {
+    border-bottom: 1px solid #e7eaee;
+  }
+}
+@media (max-width: 640px) {
+  ul.sf-menu.menu.top-workbench-menu {
+    max-width: 100%!important;
+  }
+  .top-workbench-menu-present .sidr {
+    top: 56px;
+  }
+}

--- a/source/default/_patterns/00-protons/legacy/css/components/navigation/_top-workbench-menu.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/navigation/_top-workbench-menu.css
@@ -162,6 +162,7 @@ ul.sf-menu.top-workbench-menu li.sfHover>ul, ul.sf-menu.top-workbench-menu li:ho
     height: 50px;
     position: relative;
     box-shadow:none;
+    max-width: fit-content;
   }
   .region-top-workbench-menu h2.block__title {
     width: unset;
@@ -319,6 +320,7 @@ ul.sf-menu.top-workbench-menu li.sfHover>ul, ul.sf-menu.top-workbench-menu li:ho
     width: 100%;
     background: unset;
     -webkit-text-fill-color: unset;
+    white-space: normal;
   }
   ul.sf-menu.top-workbench-menu li a:hover, ul.sf-menu.top-workbench-menu li.sf-expanded a {
     color: #112e51;
@@ -349,7 +351,8 @@ ul.sf-menu.top-workbench-menu li.sfHover>ul, ul.sf-menu.top-workbench-menu li:ho
   }
 }
 @media (max-width: 640px) {
-  ul.sf-menu.menu.top-workbench-menu {
+  ul.sf-menu.menu.top-workbench-menu,
+  .region-top-workbench-menu .block {
     max-width: 100%!important;
   }
   .top-workbench-menu-present .sidr {

--- a/source/default/_patterns/00-protons/legacy/css/components/navigation/_top-workbench-menu.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/navigation/_top-workbench-menu.css
@@ -109,7 +109,7 @@ ul.sf-menu.top-workbench-menu ul {
   background: #e7eaee;
 }
 ul.sf-menu.top-workbench-menu ul li {
-  border-bottom: 1px solid #fff;
+  border-bottom: 1px solid #e7eaee;
   word-wrap: normal;
   white-space: normal;
 }
@@ -310,7 +310,7 @@ ul.sf-menu.top-workbench-menu li.sfHover>ul, ul.sf-menu.top-workbench-menu li:ho
   ul.sf-menu.top-workbench-menu li.sfHover > ul, ul.sf-menu.top-workbench-menu li:hover > ul {
     left: unset !important;
     top: 0 !important;
-    width: 90%!important;
+    width: 91%!important;
   }
   ul.sf-menu.top-workbench-menu li a {
     font-size: 1rem;
@@ -354,6 +354,10 @@ ul.sf-menu.top-workbench-menu li.sfHover>ul, ul.sf-menu.top-workbench-menu li:ho
   ul.sf-menu.menu.top-workbench-menu,
   .region-top-workbench-menu .block {
     max-width: 100%!important;
+  }
+  ul.sf-menu.top-workbench-menu li.sfHover > ul, 
+  ul.sf-menu.top-workbench-menu li:hover > ul {
+    width: 93%!important;
   }
   .top-workbench-menu-present .sidr {
     top: 56px;

--- a/source/default/_patterns/00-protons/legacy/css/components/section/_section.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/section/_section.css
@@ -60,3 +60,7 @@
   .utc-section-bg--blue p  {
     @apply text-white;
   }
+  .utc-hero-section .container-full .themag-layout__region {
+    padding-right:0;
+    padding-left:0;
+  }

--- a/source/default/_patterns/00-protons/legacy/css/global.css
+++ b/source/default/_patterns/00-protons/legacy/css/global.css
@@ -389,10 +389,10 @@ p.more-space, li.more-space {
   @apply my-6;
 }
 h3.blue-bar {
-  @apply bg-utc-new-blue-500 p-3 m-0 mb-6 text-white w-full;
+  @apply bg-utc-new-blue-500 px-2 py-1 m-0 mb-6 text-white w-full;
 }
 h3.gold-bar {
-  @apply bg-utc-new-gold-500 p-3 m-0 mb-6 text-utc-new-blue-500 w-full;
+  @apply bg-utc-new-gold-500 px-2 py-1 m-0 mb-6 text-utc-new-blue-500 w-full;
 }
 .white-hz-rule {
   @apply bg-white w-full;
@@ -487,31 +487,36 @@ ul.pager__items li a:hover {
 /*end search page adjustments*/
 
 @media screen and (max-width: 1024px) {
-  .section-hero {@apply bg-white pt-6 relative z-1}
+  .section-hero {@apply bg-white relative z-1 shadow-utc}
   .utc-hero-image-default .order-first, .utc-hero-image-default .order-last {
     order: unset!important;
   }
   .utc-hero-image-default .order-first {
     @apply mt-8;
   }
-  .node__content > .section-hero:first-child {
+  .node__content > .utc-hero-section:first-child {
     @apply p-0 -mt-4
   }
-  .node__content > .section-hero:first-child .themag-layout__region {
+  .node__content > .utc-hero-section:first-child .themag-layout__region {
     @apply p-0;
   }
 }
 @media screen and (max-width: 768px) {
   main {
-    @apply pt-4;
+    @apply pt-4 z-1 relative;
+  }
+  main.main-reduce-top-margin {
+    @apply pt-0;
   }
   .container-full, .themag-layout--my-default {
     @apply px-4;
   }
-  .section-hero .container-full {
+  .section-hero .container-full, 
+  .utc-hero-section .container-full {
     @apply p-0;
   }
-  .section-hero .container-full .row {
+  .section-hero .container-full .row, 
+  .utc-hero-section .container-full .row  {
     @apply mx-0;
   }
   .container-full .block--region-content-header.block--page-title-block .page-title {

--- a/source/default/_patterns/00-protons/legacy/js/top-workbench-menu.js
+++ b/source/default/_patterns/00-protons/legacy/js/top-workbench-menu.js
@@ -1,0 +1,49 @@
+(function($, Drupal, drupalSettings) {
+    "use strict";
+
+    Drupal.behaviors.topworkbenchmenu = {
+        attach: function(context, settings) {
+
+            /***get the workbench's footer homepage link and turn twm block title into a home link.****/
+            var homepage = document.querySelector('.department-info-- .social-media-links--platforms a[title="Back to our departmental homepage"]');
+            var homepageHref = homepage.href;
+            var twmBlockTitle = document.querySelector('.region-top-workbench-menu .block__title');
+            var twmBlockTitleSpan = document.querySelector('.region-top-workbench-menu .block__title .title-text');
+            var twmBlockTitleText = twmBlockTitleSpan.textContent;
+            var replacementBlockTitleHTML = '<a href="'+ homepageHref +'" title="'+ twmBlockTitleText +'" class="homepage-link" ><span class="title-text">'+ twmBlockTitleText +'</a>';
+            twmBlockTitle.innerHTML = replacementBlockTitleHTML ;
+
+            /***define the needles***/
+            var handshake = "Handshake";
+            var facebook = "Facebook";
+            var twitter = "Twitter";
+            var instagram = "Instagram";
+            var linkedin = "LinkedIn";
+            var youtube = "YouTube";
+            var blog = "Blog";
+
+            /***define the haystacks***/
+            var haystack = document.querySelectorAll(".twm-link");
+            var i;
+
+            /***find the needles in the haystack and add social icons***/
+            for (i = 0; i < haystack.length; i++) {
+                if(haystack[i].innerHTML == handshake){
+                    haystack[i].insertAdjacentHTML("afterbegin", '<span style="width:21px;display:inline-block"><img src="/sites/default/files/2023-02/handshake.png" style="height:15px;width:auto;display:inline;margin-top:-6px"></span>');
+                }else if(haystack[i].innerHTML == facebook){
+                   haystack[i].insertAdjacentHTML("afterbegin", '<span style="width:21px;display:inline-block"><i class="fa-brands fa-facebook-f"></i></span>');
+                }else if(haystack[i].innerHTML == twitter){
+                    haystack[i].insertAdjacentHTML("afterbegin", '<span style="width:21px;display:inline-block"><i class="fa-brands fa-twitter"></i></span>');
+                }else if(haystack[i].innerHTML == instagram){
+                    haystack[i].insertAdjacentHTML("afterbegin", '<span style="width:21px;display:inline-block"><i class="fa-brands fa-instagram"></i></span>');
+                }else if(haystack[i].innerHTML == linkedin){
+                    haystack[i].insertAdjacentHTML("afterbegin", '<span style="width:21px;display:inline-block"><i class="fa-brands fa-linkedin-in"></i></span>');
+                }else if(haystack[i].innerHTML == youtube){
+                    haystack[i].insertAdjacentHTML("afterbegin", '<span style="width:21px;display:inline-block"><i class="fa-brands fa-youtube"></i></span>');
+                }else if(haystack[i].innerHTML.indexOf(blog) !== -1){
+                    haystack[i].insertAdjacentHTML("afterbegin", '<span style="width:21px;display:inline-block"><i class="fa-solid fa-blog"></i></span>');
+                }
+            }
+        }
+    };
+}(jQuery, Drupal, drupalSettings));


### PR DESCRIPTION
This is the solution for #525. Worked with three designers on this concept. Menus are applied via context so application can be made on each workbench's page. On mobile devices, main and workbenches are integrated and dependent.

**Desktop:**
![hz-menu-desktop](https://user-images.githubusercontent.com/82905787/223486156-db7e7fb8-a8e3-402e-ad78-db736b1e7b39.gif)

![Screenshot 2023-03-07 at 11 20 16 AM](https://user-images.githubusercontent.com/82905787/223486205-2f5574fb-9e35-431e-84f9-6361c504b3bc.png)

**Tablet:**
![hz-menu-tablet](https://user-images.githubusercontent.com/82905787/223489640-9c5402dc-3efd-4476-8a99-3073c25d2cdd.gif)

**Phone:**
![hz-menu-mobile](https://user-images.githubusercontent.com/82905787/223486435-3b15d993-5b2e-42ba-9bd0-7058825347d9.gif)
### 
NOTE: This PR also contains minor mobile fixes for the full-reverse image hero.
**Before:** 
![Screenshot 2023-03-07 at 2 14 54 PM](https://user-images.githubusercontent.com/82905787/223537580-8e62df23-4f6e-404c-aaa1-49a5b32a7778.png)

**After:**
![Screenshot 2023-03-07 at 2 54 16 PM](https://user-images.githubusercontent.com/82905787/223537763-742cfb1e-185c-44a3-8ebf-eaa733154df4.png)

