### PR TITLE
UTC-2408: Remove TWM js & add library to twig.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/region/region--top-workbench-menu.html.twig
+++ b/apps/drupal-default/particle_theme/templates/region/region--top-workbench-menu.html.twig
@@ -1,0 +1,27 @@
+{#
+/**
+ * @file
+ * Theme override to display a region.
+ *
+ * Available variables:
+ * - content: The content for this region, typically blocks.
+ * - attributes: HTML attributes for the region <div>.
+ * - region: The name of the region variable as defined in the theme's
+ *   .info.yml file.
+ *
+ * @see template_preprocess_region()
+ */
+#}
+{{ attach_library('utccloud/utc-top-workbench-menus') }}
+
+{%
+  set classes = [
+    'region',
+    'region-top-workbench-menu',
+  ]
+%}
+{% if content %}
+  <div{{ attributes.addClass(classes) }}>
+    {{ content }}
+  </div>
+{% endif %}

--- a/source/default/_patterns/00-protons/index.js
+++ b/source/default/_patterns/00-protons/index.js
@@ -53,7 +53,7 @@ import './legacy/css/components/navigation/_top-workbench-menu.css';
 import './legacy/js/utc-sidebar-menu.js';
 import './legacy/js/slick-custom-arrows.js';
 import './legacy/js/utc-quoteblock.js';
-import './legacy/js/top-workbench-menu.js';
+//import './legacy/js/top-workbench-menu.js'; << now in utccloud custom modules
 // import './legacy/js/ckeditor-jquery.js';
 
 // Export global variables.

--- a/source/default/_patterns/00-protons/legacy/css/components/header/_utc_custom_header.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/header/_utc_custom_header.css
@@ -529,6 +529,9 @@ div.site-alert div.text {
     .menus-wrapper {
         padding-left:0;
     }
+    .top-workbench-menu-present.notification-alert-on .menus-wrapper {
+        padding-bottom:0!important;
+    }
 }
 
 @media screen and (max-width: 480px) {


### PR DESCRIPTION
JS errors in the console was thrown when top workbench menu element is not present on on a page. Moved js file into utccloud custom module so as only to be called in an attach library function in a twig specific to the TWM region. 

This should fix UTCCloud issue #2408: https://github.com/UTCWeb/utccloud/issues/2408

Also found that if both the Notifications alert and TWM menu are present, the padding at the bottom of the main menu needs to be 0.