### PR TITLE
UTC-537: Minor edits to back to top & mobile menu.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/layout/page/page--layout-builder-enabled.html.twig
+++ b/apps/drupal-default/particle_theme/templates/layout/page/page--layout-builder-enabled.html.twig
@@ -6,7 +6,7 @@
 <div class="layout-builder-powered-page">
    {% include '@themag/base-layout/header/header.html.twig' %}
   {# {% include '@particle/layout/header/custom-header.html.twig' %}  #}
-    <section id="mobile-menu" aria-label="mobile menu accordion" style="height:0" aria-hidden="true" >{{ page.offcanvas_sidebar }}</section>
+    <section id="mobile-menu" aria-label="mobile menu accordion" style="height:0" >{{ page.offcanvas_sidebar }}</section>
     <section aria-label="organization root menu">{{ page.top_workbench_menu }}</section>
     <section aria-label="content administrative area">{{ page.content_administration }}</section>
     <main role="main" id="main-content" tabindex="-1">

--- a/source/default/_patterns/00-protons/legacy/css/off-canvas.css
+++ b/source/default/_patterns/00-protons/legacy/css/off-canvas.css
@@ -9,3 +9,11 @@
   color: #85bef4 !important;
 
 }
+#mobile-menu {
+  display:none;
+}
+@media (max-width:768px){
+  #mobile-menu {
+    display:block;
+  }
+}

--- a/source/default/_patterns/00-protons/legacy/js/back-to-top-button.js
+++ b/source/default/_patterns/00-protons/legacy/js/back-to-top-button.js
@@ -7,7 +7,7 @@
             
             // When the user scrolls down 1500px from the top of the document, show the button
             window.onscroll = function() {scrollFunction()};
-            
+            scrollButton.style.display = "none";
             function scrollFunction() {
               if (document.body.scrollTop > 1500 || document.documentElement.scrollTop > 1500) {
                 scrollButton.style.display = "flex";


### PR DESCRIPTION
Made sure that the back button did show on page load. Only shows after scrolling down.
aria-hidden: true attribute removed from off-canvas. Off-canvas display css set to none, instead. 
