### PR TITLE
UTC-546: Update newsroom hover effect with CSS.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/views/views-view-unformatted--utc-newsroom--utc_newsroom_titles.html.twig
+++ b/apps/drupal-default/particle_theme/templates/views/views-view-unformatted--utc-newsroom--utc_newsroom_titles.html.twig
@@ -37,7 +37,7 @@
 			<a
 				href={{content.news_link}} class="text-utc-new-blue-500">
 				{# <img class="w-full" src="/mountain.jpg" alt="Mountain"> #}
-				<div class="pr-4 my-4 hover:bg-utc-new-blue-100">
+				<div class="pr-4 my-4">
 				<div class="border-l-4 border-utc-new-gold-500 py-1"> 
 				    <div class="text-base my-1 uppercase font-bold tracking-wide pl-3"> {{content.news_location}} </div>
 					<div class="text-lg mb-1 pl-3">{{ content.news_title }}</div>

--- a/source/default/_patterns/00-protons/legacy/css/global.css
+++ b/source/default/_patterns/00-protons/legacy/css/global.css
@@ -369,6 +369,21 @@ a.diagonal.light-gray-hero:hover i,
 a.diagonal.light-gray-hero:hover svg{
   @apply text-utc-new-gold-500;
 }
+/**** Newsfeed links (not cards) diagonal effects ***/
+.custom-newsfeed-css a > div {
+  background-color:transparent!important;
+  background-image: -webkit-linear-gradient(257deg, #e7eaee 50%, transparent 50%);
+  background-image: linear-gradient(-257deg, #e7eaee 50%, transparent 50%);
+  background-position: 100%;
+  background-size: 400%;
+  -webkit-transition: all 750ms ease-in-out;
+  transition: all 750ms ease-in-out;
+  font-weight:400;
+}
+.custom-newsfeed-css a > div:hover {
+  background-color:transparent!important;
+  background-position: 0;
+}
 
 b, strong {
   @apply font-bold;


### PR DESCRIPTION
Would like to update the hover effect on the newsroom title feed. Currently, it is an abrupt hover on the background color with the type inheriting the <a> bold font (which I'd like to change as well). Changes in this PR:

1. Rollover effect of background like the hero buttons.
2. Remove the bold.

It should look like this, subtle, but nice:

![latest news hover effect](https://github.com/UTCWeb/particle/assets/82905787/49708763-a339-4735-9cd1-38462ff8dcbe)
