### PR TITLE
UTC-535: Brand table block with UTC colors.

### DIFF
--- a/source/default/_patterns/00-protons/index.js
+++ b/source/default/_patterns/00-protons/index.js
@@ -45,6 +45,7 @@ import './legacy/css/components/field/_field--block-content--field-tags.css';
 import './legacy/css/components/UTC-custom-blocks/_utc_hero_video.css';
 import './legacy/css/components/UTC-custom-blocks/_utc_video_component.css';
 import './legacy/css/components/navigation/_top-workbench-menu.css';
+import './legacy/css/components/UTC-custom-blocks/_utc_table_block.css';
 // import "./legacy/css/components/UTC-custom-blocks/";
 // import "./legacy/css/components/field/";
 

--- a/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_table_block.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_table_block.css
@@ -1,0 +1,9 @@
+.table .thead-dark th {
+    color: #fff;
+    background-color: #112e51;
+    border-color: #112e51;
+  }
+  .table th, .table td {
+    border-top: 1px solid #e7eaee;
+    color: #112e51;
+  }


### PR DESCRIPTION
This only fixes the UTC brand colors on the Table block.

For the fix for the table duplication upon edits, see the config files in the UTCCloud PR: https://github.com/UTCWeb/utccloud/pull/2451
