### PR TITLE
UTC-550: Put zero height on placeholder cards.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--utc-card-base.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-card-base.html.twig
@@ -36,7 +36,8 @@
 {% if card_placeholder %}
   {% set card_classes = [
     'utc-card-2',
-    'h-100',
+    'h-0',
+    'placeholder-only',
     card_type ? 'utc-card-2--' ~ card_type,
     card_color ? 'utc-card-2--none',
     card_width ? 'utc-card-2--w-' ~ card_width,


### PR DESCRIPTION
Fix for Issue   #550: Put zero height on placeholder cards to reduce unwanted spacing, especially for mobile devices. It still has the 30px bottom margin on the parent, but is much improved. Desktops/laptops are not affected.

### Before: 
![Screenshot 2023-05-15 at 2 01 42 PM](https://github.com/UTCWeb/particle/assets/82905787/301267f2-5480-42f1-a83f-63bcd72e20ed)


### After:

**Mobile:**

![Screenshot 2023-05-15 at 5 45 24 PM](https://github.com/UTCWeb/particle/assets/82905787/c008c285-60d0-429b-87c2-b17d9da3186d)

**Desktop:**

![Screenshot 2023-05-15 at 5 48 16 PM](https://github.com/UTCWeb/particle/assets/82905787/8bd7cfec-f862-458e-8fd2-fc6189b91ee1)

