### PR TITLE
UTC-2473: This PR checks for need for js functions before calling.

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/components/card/_card.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/card/_card.css
@@ -288,4 +288,3 @@ a .utc-card-2--white.utc-card-2--card-link:hover p {
   font-size: 1.25rem;
 }
 
-img.img-fluid {width:100%; height:auto;}

--- a/source/default/_patterns/00-protons/legacy/js/back-to-top-button.js
+++ b/source/default/_patterns/00-protons/legacy/js/back-to-top-button.js
@@ -4,26 +4,32 @@
     Drupal.behaviors.backtotopbutton = {
         attach: function(context, settings) {
             let scrollButton = document.getElementById("scroll-to-top-btn");
-            
-            // When the user scrolls down 1500px from the top of the document, show the button
-            window.onscroll = function() {scrollFunction()};
             scrollButton.style.display = "none";
-            function scrollFunction() {
-              if (document.body.scrollTop > 1500 || document.documentElement.scrollTop > 1500) {
-                scrollButton.style.display = "flex";
-              } else {
-                scrollButton.style.display = "none";
-              }
-            }
             
-            // When the user clicks on the button, scroll to the top of the document
-            function topFunction() {
-              document.body.scrollTop = 0;
-              document.documentElement.scrollTop = 0;
+            //check to see if the window is tall enough for a back-to-top button
+            function setWindowHeight(){
+              var windowHeight = window.innerHeight;
+                  if (windowHeight > 1500) {
+                    // When the user scrolls down 1500px from the top of the document, show the button
+                    window.onscroll = function() {scrollFunction()};
+                    
+                    window.addEventListener("resize",setWindowHeight,false);
+                      function scrollFunction() {
+                        if (document.body.scrollTop > 1500 || document.documentElement.scrollTop > 1500) {
+                          scrollButton.style.display = "flex";
+                        } else {
+                          scrollButton.style.display = "none";
+                        }
+                      }
+                      // When the user clicks on the button, scroll to the top of the document
+                      function topFunction() {
+                        document.body.scrollTop = 0;
+                        document.documentElement.scrollTop = 0;
+                      }
+                  scrollButton.addEventListener("click", topFunction);
+                }
             }
-
-            scrollButton.addEventListener("click", topFunction);
-           
+            setWindowHeight();
         }
     };
   }(jQuery, Drupal, drupalSettings));

--- a/source/default/_patterns/00-protons/legacy/js/superfish-accessibility-attr.js
+++ b/source/default/_patterns/00-protons/legacy/js/superfish-accessibility-attr.js
@@ -26,10 +26,7 @@
                 if (window.matchMedia("(max-width: 768px)").matches) {
                     getMobileBtn.setAttribute("aria-hidden", "false");
                     getMobileMenu.setAttribute("aria-hidden", "false");
-                } else {
-                    getMobileBtn.setAttribute("aria-hidden", "true");
-                    getMobileMenu.setAttribute("aria-hidden", "true");
-                }
+                } 
             }
             mobileIconAccessibilityAttr();
 


### PR DESCRIPTION
Related to this issue [#2473](https://github.com/UTCWeb/utccloud/issues/2473) + an img.img-fluid width problem set at 100% deployed last week.

The JS was throwing errors when the item in question (back-top-button and Superfish mobile menu) were not applicable to the page.

Back to top button: Windows shorter than 1500px don't have that object.
Superfish Mobile menu: Doesn't show on screens larger than 768px.

Solution: Run an if statement to check if conditions present.

Image Fluid issue causing images to render too large. This PR removes this.: 

![Screenshot 2023-05-26 at 1 23 54 PM](https://github.com/UTCWeb/particle/assets/82905787/42d9ad29-17ca-4afe-b59f-83d7c202d164)
