### PR TITLE
UTC-558: Make bg heros responsive and blazied.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--default.html.twig
@@ -22,18 +22,19 @@
 		{% set rendered_content = content|render %}
 		{# Sets variable to trigger content render array. #}
 		{# hero_button_link: content.field_hero_button|field_value, #}
-		{% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %}
+		{#{% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %}#}
+
 		{% set utc_hero = {
-		hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_image_select)["#object"].field_image_url.value,
-		hero_align: content["#block_content"].field_hero_align.0.value,
-		hero_color: content["#block_content"].field_hero_color.0.value,
-		hero_tag: content.field_hero_tag|field_value,
-		hero_title: content.field_hero_title|field_value,
-		hero_image: content.field_utc_media|field_value,
-		hero_zoom: content.field_zoom_image[0]|render == 'On' ? '_blank',
-		hero_text: content.field_hero_text|field_value,
-		hero_button_text: content.field_hero_button.0['#title'],
-		hero_button_url: content.field_hero_button.0['#url'],
+			hero_bg: content.field_hero_bg_image|field_value,
+			hero_align: content["#block_content"].field_hero_align.0.value,
+			hero_color: content["#block_content"].field_hero_color.0.value,
+			hero_tag: content.field_hero_tag|field_value,
+			hero_title: content.field_hero_title|field_value,
+			hero_image: content.field_utc_media|field_value,
+			hero_zoom: content.field_zoom_image[0]|render == 'On' ? '_blank',
+			hero_text: content.field_hero_text|field_value,
+			hero_button_text: content.field_hero_button.0['#title'],
+			hero_button_url: content.field_hero_button.0['#url'],
 		} %}
 		{# Add zoom class if zoom is checked. #}
 		{% if utc_hero.hero_zoom %}
@@ -89,8 +90,9 @@
 						{% endblock herotextbutton %}
 						</div>
 					</div>
-					<div class="lg:max-w-full lg:ml-0 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 absolute top-0 left-0" style="background-image: url({{ utc_hero.hero_bg }})">
-						<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
+					<div class="lg:max-w-full lg:ml-0 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 absolute top-0 left-0">
+						{{ utc_hero.hero_bg }}
+						<div class="h-full w-full absolute top-0 {{ bg2_opacity }}" style="{{ bg_color }}"></div>
 					</div>
 				</div>
 		</div>

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-center.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-center.html.twig
@@ -22,9 +22,10 @@
 	{% set rendered_content = content|render %}
 	{# Sets variable to trigger content render array. #}
 	{# hero_button_link: content.field_hero_button|field_value, #}
-	{% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %}
+	{# {% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %} #}
+
 	{% set utc_hero = {
-		hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_image_select)["#object"].field_image_url.value,
+		hero_bg: content.field_hero_bg_image|field_value,
 		hero_align: content["#block_content"].field_hero_align.0.value,
 		hero_color: content["#block_content"].field_hero_color.0.value,
 		hero_tag: content.field_hero_tag|field_value,
@@ -83,11 +84,12 @@
 						{% endblock %}
 					</div>
 			{% if utc_hero.hero_align == 'Left' %}
-				<div class="lg:max-w-full lg:ml-0 absolute top-0 left-0 lg:static md:col-start-2 md:col-end-5 md:row-start-1 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10" style="background-image: url({{ utc_hero.hero_bg }})">
+				<div class="lg:max-w-full lg:ml-0 absolute top-0 left-0 lg:relative md:col-start-2 md:col-end-5 md:row-start-1 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10" >
 			{% else %}
-				<div class="lg:max-w-full lg:ml-0 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-4 md:row-start-1 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10" style="background-image: url({{ utc_hero.hero_bg }})">
+				<div class="lg:max-w-full lg:ml-0 absolute top-0 left-0 lg:relative md:col-start-1 md:col-end-4 md:row-start-1 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10" >
 			{% endif %}
-					<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
+					{{ utc_hero.hero_bg }}
+					<div class="h-full w-full absolute top-0 {{ bg2_opacity }}" style="{{ bg_color }}"></div>
 				</div>
 			</div>
 	</div>

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-reverse.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full-reverse.html.twig
@@ -22,9 +22,9 @@
 	{% set rendered_content = content|render %}
 	{# Sets variable to trigger content render array. #}
 	{# hero_button_link: content.field_hero_button|field_value, #}
-	{% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %}
+	
 	{% set utc_hero = {
-		hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_image_select)["#object"].field_image_url.value,
+		hero_bg: content.field_hero_bg_image|field_value,
 		hero_align: content["#block_content"].field_hero_align.0.value,
 		hero_color: content["#block_content"].field_hero_color.0.value,
 		hero_tag: content.field_hero_tag|field_value,
@@ -62,9 +62,9 @@
 	{% endif %}
 	<div {{ attributes.addClass(classes) }}>
 		{% if utc_hero.hero_align == 'Left' %}
-			<div class="utc-hero-block lg:grid lg:grid-rows-utcheroreverse lg:grid-cols-utchero lg:gap-y-4 lg:grid-flow-row lg:mb-4 text-center shadow-utc relative">
+			<div class="utc-hero-block lg:grid lg:grid-rows-utcheroreverse lg:grid-cols-utchero lg:gap-y-4 lg:grid-flow-row lg:mb-4 text-center shadow-utcbottom relative">
 				{% if utc_hero.hero_image %}
-					<div class="lg:col-start-2 lg:col-end-3 lg:row-start-1 lg:row-end-4 lg:m-auto col-span-1 z-30 {{ utc_zoom }} shadow-utcdark relative">
+					<div class="lg:col-start-2 lg:col-end-3 lg:row-start-1 lg:row-end-4 lg:m-auto col-span-1 z-30 {{ utc_zoom }} shadow-utcbottom relative">
 						{{ utc_hero.hero_image }} 
 					</div>
 				{% endif %}
@@ -83,12 +83,14 @@
 						{% endblock %}
 					</div>
 		{% if utc_hero.hero_align == 'Left' %}			
-				<div class="lg:max-w-full lg:max-w-full lg:md-0 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-5 md:row-start-2 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 shadow-utcdark" style="background-image: url({{ utc_hero.hero_bg }})">
-					<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
+				<div class="lg:max-w-full lg:max-w-full lg:md-0 absolute top-0 left-0 lg:relative md:col-start-1 md:col-end-5 md:row-start-2 md:row-end-5 w-full h-full {{ bg1_opacity }} z-10 shadow-utcbottom" >
+					{{ utc_hero.hero_bg }}
+					<div class="h-full w-full absolute top-0 {{ bg2_opacity }}" style="{{ bg_color }}"></div>
 				</div>
 		{% else %}
-				<div class="lg:max-w-full lg:max-w-full lg:md-0 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-5 md:row-start-2 md:row-end-5 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 shadow-utcdark" style="background-image: url({{ utc_hero.hero_bg }})">
-					<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
+				<div class="lg:max-w-full lg:max-w-full lg:md-0 absolute top-0 left-0 lg:relative md:col-start-1 md:col-end-5 md:row-start-2 md:row-end-5 w-full h-full {{ bg1_opacity }} z-10 shadow-utcbottom" >
+					{{ utc_hero.hero_bg }}
+					<div class="h-full w-full absolute top-0 {{ bg2_opacity }}" style="{{ bg_color }}"></div>
 				</div>
 		{% endif %}
 			</div>

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
@@ -15,10 +15,8 @@
 	{{ attach_library('utccloud/utc-hero-image') }}
 	{% set rendered_content = content|render %}
 	{# Sets variable to trigger content render array. #}
-	{# hero_button_link: content.field_hero_button|field_value, #}
-	{% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %}
 	{% set utc_hero = {
-		hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_image_select)["#object"].field_image_url.value,
+		hero_bg: content.field_hero_bg_image|field_value,
 		hero_align: content["#block_content"].field_hero_align.0.value,
 		hero_color: content["#block_content"].field_hero_color.0.value,
 		hero_tag: content.field_hero_tag|field_value,
@@ -43,7 +41,8 @@
 		{% set btn_border_color = "border-white" %}
 		{% set bg_color = 'background-color:#112e51' %}
 		{% set bg1_opacity = '' %}
-    	{% set bg2_opacity = 'opacity-90' %}
+    	{% set bg2_opacity = 'opacity-85' %}
+		{% set hr_color = 'border-utc-new-gold-500' %}
 	{% else %}
 		{% set title_color = 'text-utc-new-blue-500' %}
 		{% set body_color = 'text-utc-new-blue-500' %}
@@ -53,11 +52,13 @@
 		{% set bg_color = 'background-color:#104dd4' %}
 		{% set bg1_opacity = 'opacity-20' %}
     	{% set bg2_opacity = 'opacity-20' %}
+		{% set hr_color = 'border-utc-new-blue-500' %}
 	{% endif %}
+
 	{# image on left #}	 
 	<div {{ attributes.addClass(classes) }}>
 		{% if utc_hero.hero_align == 'Left' %}
-			<div class="utc-hero-block lg:grid lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-4 lg:grid-flow-row lg:mb-4 text-center">
+			<div class="utc-hero-block lg:grid lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-4 lg:grid-flow-row text-center">
 				{% if utc_hero.hero_image %}
 					<div class="lg:col-start-2 lg:col-end-3 lg:row-start-2 lg:row-end-6 lg:m-auto col-span-1 z-30 {{ utc_zoom }} relative shadow-utcdark ">
 						{{ utc_hero.hero_image }} 
@@ -66,7 +67,7 @@
 					<div class="lg:col-start-3 lg:col-end-4 lg:row-start-1 lg:row-end-4 lg:my-auto lg:ml-8 px-4 py-8 relative z-30">
 		{% else %}
 		{# image on right #}	
-			<div class="utc-hero-block lg:grid lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-6 grid-flow-row lg:mb-4 text-center">
+			<div class="utc-hero-block lg:grid lg:grid-rows-utchero lg:grid-cols-utcheroright lg:gap-y-6 grid-flow-row text-center">
 				{% if utc_hero.hero_image %}
 					<div class="lg:col-start-3 lg:col-end-4 lg:row-start-2 lg:row-end-5 lg:m-auto z-30 {{ utc_zoom }} relative shadow-utcdark ">
 						{{ utc_hero.hero_image }}
@@ -80,7 +81,7 @@
 							<p class="hero-tag text-left font-semibold tracking-wide uppercase text-lg mb-0 mt-4 {{ tag_color }}">
 								{{ utc_hero.hero_tag }}
 							</p>
-							<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20 ml-0" />
+							<hr class="border-t-3 {{ hr_color }} mt-2 mb-6 w-20 ml-0" />
 						{% endif %}
 						{% if utc_hero.hero_title %}
 							<h2 class="text-left mb-2 {{ title_color }}">
@@ -105,8 +106,9 @@
 					{% endblock herocontent %}
 					</div>
 					{% block herobackground %}
-						<div class="lg:max-w-full lg:ml-0 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 absolute top-0 left-0 lg:static md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-4" style="background-image: url({{ utc_hero.hero_bg }})">
-							<div class="h-full w-full {{ bg2_opacity }}" style="{{ bg_color }}"></div>
+						<div class="overflow-hidden lg:max-w-full lg:ml-0 w-full h-full {{ bg1_opacity }} bg-cover bg-center z-10 absolute top-0 left-0 lg:relative md:col-start-1 md:col-end-5 md:row-start-1 md:row-end-4">
+							{{ utc_hero.hero_bg }}
+							<div class="h-full w-full absolute top-0 {{ bg2_opacity }}" style="{{ bg_color }}"></div>
 						</div>
 					{% endblock herobackground %}
 			</div>

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero-video--default.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero-video--default.html.twig
@@ -28,9 +28,10 @@
 		{% set rendered_content = content|render %}
 		{# Sets variable to trigger content render array. #}
 		{# hero_button_link: content.field_hero_button|field_value, #}
-		{% set hero_video_select = content["#block_content"].field_hero_bg_image.0.target_id %}
+		{#{% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %}#}
+
 		{% set utc_hero = {
-			hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_video_select)["#object"].field_image_url.value,
+			hero_bg: content.field_hero_bg_image|field_value,
 			hero_align: content["#block_content"].field_hero_align.0.value,
 			hero_color: content["#block_content"].field_hero_color.0.value,
 			hero_tag: content.field_hero_tag_text|field_value,
@@ -53,6 +54,7 @@
 			{% set btn_class = "default" %}
 			{% set bg1_opacity = '' %}
 			{% set bg2_opacity = 'opacity:.87;' %}
+			{% set hr_color = 'border-utc-new-gold-500' %}
 		{% else %}
 			{% set title_color = 'text-utc-new-blue-500' %}
 			{% set body_color = 'text-base' %}
@@ -62,12 +64,13 @@
 			{% set bg_color = 'background-color:#5c7fb4;' %}
 			{% set bg1_opacity = 'opacity-25' %}
 			{% set bg2_opacity = 'opacity:.12;' %}
+			{% set hr_color = 'border-utc-new-blue-500' %}
 		{% endif %}
 		{# image on left #}
 		{% if utc_hero.hero_align == 'Left' %}
 			{% block herobackgroundleft %}
 				<div class="video-hero-wrapper w-full h-full p-12 relative">
-					<span class="absolute left-0 top-0 right-0 bottom-0 {{ bg1_opacity }} bg-cover bg-center" style="background-image: url({{ utc_hero.hero_bg }})"></span>
+					<span class="absolute left-0 top-0 right-0 bottom-0 overflow-hidden {{ bg1_opacity }}">{{ utc_hero.hero_bg }}</span>
 					<div class="absolute left-0 top-0 hero-background-color h-full w-full " style="{{ bg2_opacity }} {{ bg_color }}"></div>
 					<div class="utc-video-hero-container utc-video-hero-block-left flex flex-col lg:grid lg:grid-cols-utcvideohero lg:gap-10 relative ">
 						<div>
@@ -78,7 +81,7 @@
 								<p class="hero-tag text-left font-semibold tracking-wide uppercase text-lg mb-0 mt-4 {{ tag_color }}">
 									{{ utc_hero.hero_tag }}
 								</p>
-								<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20 ml-0" />
+								<hr class="border-t-3 {{ hr_color }} mt-2 mb-6 w-20 ml-0" />
 							{% endif %}
 							{% if utc_hero.hero_title %}
 								<h2 class="text-left mb-2 {{ title_color }}">
@@ -105,15 +108,15 @@
 		{# image on right #}	
 			{% block herobackgroundright %}
 				<div class="video-hero-wrapper w-full h-full p-12 relative">
-					<span class="absolute left-0 top-0 right-0 bottom-0 {{ bg1_opacity }} bg-cover bg-center" style="background-image: url({{ utc_hero.hero_bg }})"></span>
+					<span class="absolute left-0 top-0 right-0 bottom-0 overflow-hidden {{ bg1_opacity }}">{{ utc_hero.hero_bg }}</span>
 					<div class="absolute left-0 top-0 hero-background-color h-full w-full" style="{{ bg2_opacity }};{{ bg_color }}"></div>
 					<div class="utc-video-hero-container utc-video-hero-block-right flex flex-col-reverse lg:grid lg:grid-cols-utcvideoheroright lg:gap-10 relative ">
 						<div class="flex flex-col justify-center shrink relative">
 							{% if utc_hero.hero_tag %}
-								<p class="hero-tag text-left font-semibold tracking-wide uppercase text-lg mb-0 mt-4 {{ tag_color }} lg:whitespace-nowrap">
+								<p class="hero-tag text-left font-semibold tracking-wide uppercase text-lg mb-0 mt-4 {{ tag_color }}">
 									{{ utc_hero.hero_tag }}
 								</p>
-								<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20 ml-0" />
+								<hr class="border-t-3 {{ hr_color }} mt-2 mb-6 w-20 ml-0" />
 							{% endif %}
 							{% if utc_hero.hero_title %}
 								<h2 class="text-left mb-2 {{ title_color }}">

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero-video--full-center.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero-video--full-center.html.twig
@@ -31,9 +31,10 @@
 		{% set rendered_content = content|render %}
 		{# Sets variable to trigger content render array. #}
 		{# hero_button_link: content.field_hero_button|field_value, #}
-		{% set hero_video_select = content["#block_content"].field_hero_bg_image.0.target_id %}
+		{#{% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %}#}
+
 		{% set utc_hero = {
-			hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_video_select)["#object"].field_image_url.value,
+			hero_bg: content.field_hero_bg_image|field_value,
 			hero_align: content["#block_content"].field_hero_align.0.value,
 			hero_color: content["#block_content"].field_hero_color.0.value,
 			hero_tag: content.field_hero_tag_text|field_value,
@@ -56,6 +57,7 @@
 			{% set btn_class = "default" %}
 			{% set bg1_opacity = '' %}
 			{% set bg2_opacity = 'opacity:.87;' %}
+			{% set hr_color = 'border-utc-new-gold-500' %}
 		{% else %}
 			{% set title_color = 'text-utc-new-blue-500' %}
 			{% set body_color = 'text-base' %}
@@ -65,12 +67,13 @@
 			{% set bg_color = 'background-color:#5c7fb4;' %}
 			{% set bg1_opacity = 'opacity-25' %}
 			{% set bg2_opacity = 'opacity:.12;' %}
+			{% set hr_color = 'border-utc-new-blue-500' %}
 		{% endif %}
 		{# image on left #}
 		{% if utc_hero.hero_align == 'Left' %}
 			{% block herobackgroundleft %}
 				<div class="video-hero-wrapper left h-full p-12 lg:pl-0 relative">
-					<div class="absolute top-0 right-0 bottom-0 lg:max-w-95p overflow-x-hidden {{ bg1_opacity }} bg-cover bg-center w-full" style="background-image: url({{ utc_hero.hero_bg }})"></div>
+					<span class="absolute top-0 right-0 bottom-0 overflow-hidden w-full lg:w-95p {{ bg1_opacity }}" >{{ utc_hero.hero_bg }}</span>
 					<div class="absolute right-0 top-0 hero-background-color h-full lg:max-w-95p overflow-x-hidden w-full" style="{{ bg2_opacity }} {{ bg_color }} "></div>
 					<div class="utc-video-hero-container utc-video-hero-block-left w-full flex flex-col lg:grid lg:gap-10 relative">
 						<div class="flex flex-column justify-center">
@@ -81,7 +84,7 @@
 								<p class="hero-tag text-left font-semibold tracking-wide uppercase text-lg mb-0 mt-4 {{ tag_color }}">
 									{{ utc_hero.hero_tag }}
 								</p>
-								<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20 ml-0" />
+								<hr class="border-t-3 {{ hr_color }} mt-2 mb-6 w-20 ml-0" />
 							{% endif %}
 							{% if utc_hero.hero_title %}
 								<h2 class="text-left mb-2 {{ title_color }}">
@@ -108,15 +111,15 @@
 		{# image on right #}	
 			{% block herobackgroundright %}
 				<div class="video-hero-wrapper right h-full p-12 relative">
-					<div class="absolute left-0 top-0 right-0 bottom-0 lg:max-w-95p overflow-x-hidden {{ bg1_opacity }} bg-cover bg-center w-full" style="background-image: url({{ utc_hero.hero_bg }})"></div>
+					<span class="absolute left-0 top-0 bottom-0 overflow-hidden w-full lg:w-95p  {{ bg1_opacity }}">{{ utc_hero.hero_bg }}</span>
 					<div class="absolute left-0 top-0 hero-background-color h-full lg:max-w-95p overflow-x-hidden w-full" style="{{ bg2_opacity }} {{ bg_color }} "></div>
 					<div class="utc-video-hero-container utc-video-hero-block-right w-full flex flex-col-reverse lg:grid lg:gap-10 relative ">
 						<div class="flex flex-col justify-center shrink relative">
 							{% if utc_hero.hero_tag %}
-								<p class="hero-tag text-left font-semibold tracking-wide uppercase text-lg mb-0 mt-4 {{ tag_color }} lg:whitespace-nowrap">
+								<p class="hero-tag text-left font-semibold tracking-wide uppercase text-lg mb-0 mt-4 {{ tag_color }}">
 									{{ utc_hero.hero_tag }}
 								</p>
-								<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20 ml-0" />
+								<hr class="border-t-3 {{ hr_color }} mt-2 mb-6 w-20 ml-0" />
 							{% endif %}
 							{% if utc_hero.hero_title %}
 								<h2 class="text-left mb-2 {{ title_color }}">

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero-video--full-reverse.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero-video--full-reverse.html.twig
@@ -30,9 +30,10 @@
 		{% set rendered_content = content|render %}
 		{# Sets variable to trigger content render array. #}
 		{# hero_button_link: content.field_hero_button|field_value, #}
-		{% set hero_video_select = content["#block_content"].field_hero_bg_image.0.target_id %}
+		{#{% set hero_image_select = content["#block_content"].field_hero_bg_image.0.target_id %}#}
+
 		{% set utc_hero = {
-			hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_video_select)["#object"].field_image_url.value,
+			hero_bg: content.field_hero_bg_image|field_value,
 			hero_align: content["#block_content"].field_hero_align.0.value,
 			hero_color: content["#block_content"].field_hero_color.0.value,
 			hero_tag: content.field_hero_tag_text|field_value,
@@ -55,6 +56,7 @@
 			{% set btn_class = "default" %}
 			{% set bg1_opacity = '' %}
 			{% set bg2_opacity = 'opacity:.87;' %}
+			{% set hr_color = 'border-utc-new-gold-500' %}
 		{% else %}
 			{% set title_color = 'text-utc-new-blue-500' %}
 			{% set body_color = 'text-base' %}
@@ -64,12 +66,13 @@
 			{% set bg_color = 'background-color:#5c7fb4;' %}
 			{% set bg1_opacity = 'opacity-25' %}
 			{% set bg2_opacity = 'opacity:.12;' %}
+			{% set hr_color = 'border-utc-new-blue-500' %}
 		{% endif %}
 		{# image on left #}
 		{% if utc_hero.hero_align == 'Left' %}
 			{% block herobackgroundleft %}
 				<div class="video-hero-wrapper w-full h-full px-12 pt-12 relative">
-					<span class="absolute left-0 top-0 right-0 bottom-0 {{ bg1_opacity }} bg-cover bg-center" style="background-image: url({{ utc_hero.hero_bg }})"></span>
+					<span class="absolute left-0 top-0 right-0 bottom-0 overflow-hidden {{ bg1_opacity }}">{{ utc_hero.hero_bg }}</span>
 					<div class="absolute left-0 top-0 hero-background-color h-full w-full " style="{{ bg2_opacity }} {{ bg_color }}"></div>
 					<div class="utc-video-hero-container utc-video-hero-block-left flex flex-col lg:grid lg:grid-cols-utcvideohero lg:gap-10 relative ">
 						<div class="lg:-mt-28 lg:mb-20">
@@ -80,7 +83,7 @@
 								<p class="hero-tag text-left font-semibold tracking-wide uppercase text-lg mb-0 mt-4 {{ tag_color }}">
 									{{ utc_hero.hero_tag }}
 								</p>
-								<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20 ml-0" />
+								<hr class="border-t-3 {{ hr_color }} mt-2 mb-6 w-20 ml-0" />
 							{% endif %}
 							{% if utc_hero.hero_title %}
 								<h2 class="text-left mb-2 {{ title_color }}">
@@ -107,15 +110,15 @@
 		{# image on right #}	
 			{% block herobackgroundright %}
 				<div class="video-hero-wrapper w-full h-full px-12 pt-12 relative">
-					<span class="absolute left-0 top-0 right-0 bottom-0 {{ bg1_opacity }} bg-cover bg-center" style="background-image: url({{ utc_hero.hero_bg }})"></span>
+					<span class="absolute left-0 top-0 right-0 bottom-0 overflow-hidden {{ bg1_opacity }}">{{ utc_hero.hero_bg }}</span>
 					<div class="absolute left-0 top-0 hero-background-color h-full w-full " style="{{ bg2_opacity }} {{ bg_color }}"></div>
 					<div class="utc-video-hero-container utc-video-hero-block-right flex flex-col-reverse lg:grid lg:grid-cols-utcvideoheroright lg:gap-10 relative ">
 						<div class="flex flex-col justify-center shrink relative">
 							{% if utc_hero.hero_tag %}
-								<p class="hero-tag text-left font-semibold tracking-wide uppercase text-lg mb-0 mt-4 {{ tag_color }} lg:whitespace-nowrap">
+								<p class="hero-tag text-left font-semibold tracking-wide uppercase text-lg mb-0 mt-4 {{ tag_color }}">
 									{{ utc_hero.hero_tag }}
 								</p>
-								<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20 ml-0" />
+								<hr class="border-t-3 {{ hr_color }} mt-2 mb-6 w-20 ml-0" />
 							{% endif %}
 							{% if utc_hero.hero_title %}
 								<h2 class="text-left mb-2 {{ title_color }}">

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero-video--full.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero-video--full.html.twig
@@ -29,9 +29,9 @@
 		{% set rendered_content = content|render %}
 		{# Sets variable to trigger content render array. #}
 		{# hero_button_link: content.field_hero_button|field_value, #}
-		{% set hero_video_select = content["#block_content"].field_hero_bg_image.0.target_id %}
+
 		{% set utc_hero = {
-			hero_bg: drupal_field('field_image_url', 'taxonomy_term', hero_video_select)["#object"].field_image_url.value,
+            hero_bg: content.field_hero_bg_image|field_value,
 			hero_align: content["#block_content"].field_hero_align.0.value,
 			hero_color: content["#block_content"].field_hero_color.0.value,
 			hero_tag: content.field_hero_tag_text|field_value,
@@ -54,6 +54,7 @@
 			{% set btn_class = "default" %}
 			{% set bg1_opacity = '' %}
 			{% set bg2_opacity = 'opacity:.87;' %}
+			{% set hr_color = 'border-utc-new-gold-500' %}
 		{% else %}
 			{% set title_color = 'text-utc-new-blue-500' %}
 			{% set body_color = 'text-base' %}
@@ -63,14 +64,15 @@
 			{% set bg_color = 'background-color:#5c7fb4;' %}
 			{% set bg1_opacity = 'opacity-25' %}
 			{% set bg2_opacity = 'opacity:.12;' %}
+			{% set hr_color = 'border-utc-new-blue-500' %}
 		{% endif %}
 		{# image on left #}
 		{% if utc_hero.hero_align == 'Left' %}
 			{% block herobackgroundleft %}
 				<div class="video-hero-wrapper w-full h-full px-12 relative">
-					<span class="absolute left-0 top-0 right-0 bottom-0 {{ bg1_opacity }} bg-cover bg-center" style="background-image: url({{ utc_hero.hero_bg }})"></span>
+					<span class="absolute left-0 top-0 right-0 bottom-0 overflow-hidden {{ bg1_opacity }}">{{ utc_hero.hero_bg }}</span>
 					<div class="absolute left-0 top-0 hero-background-color h-full w-full " style="{{ bg2_opacity }} {{ bg_color }}"></div>
-					<div class="utc-video-hero-container utc-video-hero-block-left flex flex-col lg:grid lg:grid-cols-utcvideohero lg:gap-10 relative ">
+					<div class="utc-video-hero-container utc-video-hero-block-left flex flex-col md:grid md:grid-cols-utcvideohero md:gap-10 relative ">
 						<div>
 							<div class="video-hero {{ utc_hero.hero_parameters[0] }} {{ utc_hero.hero_parameters[1] }} {{ utc_hero.hero_parameters[2] }} ">{{ utc_hero.hero_video }}{{ utc_hero.hero_otherhost }}</div>
 						</div >
@@ -79,7 +81,7 @@
 								<p class="hero-tag text-left font-semibold tracking-wide uppercase text-lg mb-0 mt-4 {{ tag_color }}">
 									{{ utc_hero.hero_tag }}
 								</p>
-								<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20 ml-0" />
+								<hr class="border-t-3 {{ hr_color }} mt-2 mb-6 w-20 ml-0" />
 							{% endif %}
 							{% if utc_hero.hero_title %}
 								<h2 class="text-left mb-2 {{ title_color }}">
@@ -106,15 +108,15 @@
 		{# image on right #}	
 			{% block herobackgroundright %}
 				<div class="video-hero-wrapper w-full h-full px-12 relative">
-					<span class="absolute left-0 top-0 right-0 bottom-0 {{ bg1_opacity }} bg-cover bg-center" style="background-image: url({{ utc_hero.hero_bg }})"></span>
+					<span class="absolute left-0 top-0 right-0 bottom-0 overflow-hidden {{ bg1_opacity }}">{{ utc_hero.hero_bg }}</span>
 					<div class="absolute left-0 top-0 hero-background-color h-full w-full " style="{{ bg2_opacity }} {{ bg_color }}"></div>
-					<div class="utc-video-hero-container utc-video-hero-block-right flex flex-col-reverse lg:grid lg:grid-cols-utcvideoheroright lg:gap-10 relative ">
+					<div class="utc-video-hero-container utc-video-hero-block-right flex flex-col-reverse md:grid md:grid-cols-utcvideoheroright md:gap-10 relative ">
 						<div class="flex flex-col justify-center shrink relative">
 							{% if utc_hero.hero_tag %}
-								<p class="hero-tag text-left font-semibold tracking-wide uppercase text-lg mb-0 mt-4 {{ tag_color }} lg:whitespace-nowrap">
+								<p class="hero-tag text-left font-semibold tracking-wide uppercase text-lg mb-0 mt-4 {{ tag_color }}">
 									{{ utc_hero.hero_tag }}
 								</p>
-								<hr class="border-t-3 border-utc-new-gold-500 mt-2 mb-6 w-20 ml-0" />
+								<hr class="border-t-3 {{ hr_color }} mt-2 mb-6 w-20 ml-0" />
 							{% endif %}
 							{% if utc_hero.hero_title %}
 								<h2 class="text-left mb-2 {{ title_color }}">

--- a/apps/drupal-default/particle_theme/templates/content/taxonomy/taxonomy-term--hero-images.html.twig
+++ b/apps/drupal-default/particle_theme/templates/content/taxonomy/taxonomy-term--hero-images.html.twig
@@ -1,0 +1,31 @@
+{#
+/**
+ * @file
+ * Theme override to display a taxonomy term.
+ *
+ * Available variables:
+ * - url: URL of the current term.
+ * - name: (optional) Name of the current term.
+ * - content: Items for the content of the term (fields and description).
+ *   Use 'content' to print them all, or print a subset such as
+ *   'content.description'. Use the following code to exclude the
+ *   printing of a given child element:
+ *   @code
+ *   {{ content|without('description') }}
+ *   @endcode
+ * - attributes: HTML attributes for the wrapper.
+ * - page: Flag for the full page state.
+ * - term: The taxonomy term entity, including:
+ *   - id: The ID of the taxonomy term.
+ *   - bundle: Machine name of the current vocabulary.
+ * - view_mode: View mode, e.g. 'full', 'teaser', etc.
+ *
+ * @see template_preprocess_taxonomy_term()
+ */
+#}
+
+
+{{ content }}
+
+
+

--- a/apps/drupal-default/particle_theme/templates/field/field--field-hero-bg-image.html.twig
+++ b/apps/drupal-default/particle_theme/templates/field/field--field-hero-bg-image.html.twig
@@ -1,0 +1,6 @@
+{# Need to strip out all field elements and attributes to just get the entity #}
+{% spaceless %}
+  {% for item in items %}
+    {{ item.content }}
+  {% endfor %}
+{% endspaceless %}

--- a/apps/drupal-default/particle_theme/templates/field/field--taxonomy-term--field-hero-image.html.twig
+++ b/apps/drupal-default/particle_theme/templates/field/field--taxonomy-term--field-hero-image.html.twig
@@ -1,0 +1,6 @@
+{# Need to strip out all field elements and attributes to just get the entity #}
+{% spaceless %}
+  {% for item in items %}
+    {{ item.content }}
+  {% endfor %}
+{% endspaceless %}

--- a/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_hero_video.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_hero_video.css
@@ -28,12 +28,6 @@
 .container-full .block--utc-video-hero .video-hero-wrapper {@apply pb-0;}
 .container .block--utc-video-hero .video-hero-wrapper {@apply pb-8;}
 
-/*.block--utc-video-hero-full-center .video-hero-wrapper {width:98%;}
-.block--utc-video-hero-full-center .video-hero-wrapper.left {margin-left:3%!important;}
-.block--utc-video-hero-full-center .utc-video-hero-block-left {margin-left:-3%;}
-.block--utc-video-hero-full-center .video-hero-wrapper.right {margin-right:3%;}
-.block--utc-video-hero-full-center .utc-video-hero-block-right {margin-left:3%;margin-right:-7%;}*/
-
 .block--utc-video-hero-full {@apply mb-24;}
 
 .block--utc-video-hero-full-center .utc-video-hero-block-left {
@@ -46,7 +40,29 @@
 .block.block--utc-video-hero.block--utc-video-hero-full {
     margin-bottom: 6rem;
 }
-@media (max-width:1023px) {
+
+@media (max-width:1023px){
+    .container .block--utc-video-hero .video-hero-wrapper, .container-full .block--utc-video-hero .video-hero-wrapper {@apply pb-4;}
+    .main-reduce-top-margin-video {margin-top: 1rem;padding-top: 0;}
+    .utc-video-hero-container{
+        padding-top: 2rem;
+        padding-bottom: 2rem;
+    }
+    .container .block--utc-video-hero-full .video-hero.responsive-video iframe, 
+    .container .block--utc-video-hero-full .video-hero.responsive-video object, 
+    .container .block--utc-video-hero-full .video-hero.responsive-video embed,
+    .container-full .block--utc-video-hero-full .video-hero.responsive-video iframe, 
+    .container-full .block--utc-video-hero-full .video-hero.responsive-video object, 
+    .container-full .block--utc-video-hero-full .video-hero.responsive-video embed,
+    .container-full .block--utc-video-hero-full-center .video-hero.responsive-video iframe, 
+    .container-full .block--utc-video-hero-full-center .video-hero.responsive-video object, 
+    .container-full .block--utc-video-hero-full-center .video-hero.responsive-video embed { top:0!important;}
+}
+@media (max-width:768px) {
+    .utc-video-hero-container{
+        padding-top: 0rem;
+        padding-bottom: 0rem;
+    }
     .container .block--utc-video-hero-full .video-hero.responsive-video iframe, 
     .container .block--utc-video-hero-full .video-hero.responsive-video object, 
     .container .block--utc-video-hero-full .video-hero.responsive-video embed,
@@ -63,8 +79,6 @@
     .utc-hero-block {@apply p-8}
     .section-container--utc-video-hero:nth-child(1) {@apply pt-0 -mt-4;}
     .block--utc-video-hero-full-center .utc-video-hero-block-right {@apply ml-0}
-}
-@media (max-width: 768px){
     .container-full .block--utc-video-hero .video-hero-wrapper, .container .block--utc-video-hero .video-hero-wrapper, .block--utc-video-hero-full .video-hero-wrapper {
         padding-top: 4rem;
     }
@@ -79,14 +93,5 @@
     .utc-video-hero-container {
         max-width: 80%!important;
         margin: 0 auto!important;
-    }
-}
-/****NOTE: THIS IS TEMPORARY UNTIL WE GET A RESPONSIVE IMAGE TYPE IN THE BACKGROUND FOR BETTER PERFORMANCE****/
-@media (max-width: 768px){
-    .bg-cover {
-        background-image: none!important;
-    }
-    .opacity-20.bg-cover {
-        background: rgba(17,46,81,.6);
     }
 }

--- a/source/default/_patterns/00-protons/legacy/css/global.css
+++ b/source/default/_patterns/00-protons/legacy/css/global.css
@@ -343,6 +343,7 @@ a.diagonal, .utc-hero-block a.diagonal {
   background-size: 400%;
   -webkit-transition: all 750ms ease-in-out;
   transition: all 750ms ease-in-out;
+  white-space: nowrap;
 }
 a.diagonal:hover, .utc-hero-block a.diagonal:hover {
   background-position: 0;
@@ -487,7 +488,7 @@ ul.pager__items li a:hover {
 /*end search page adjustments*/
 
 @media screen and (max-width: 1024px) {
-  .section-hero {@apply bg-white relative z-1 shadow-utc}
+  .section-hero {@apply relative z-1}
   .utc-hero-image-default .order-first, .utc-hero-image-default .order-last {
     order: unset!important;
   }
@@ -500,17 +501,13 @@ ul.pager__items li a:hover {
   .node__content > .utc-hero-section:first-child .themag-layout__region {
     @apply p-0;
   }
-}
-@media screen and (max-width: 768px) {
+  main.main-reduce-top-margin {
+    @apply pt-0 -mt-4;
+  }
   main {
     @apply pt-4 z-1 relative;
   }
-  main.main-reduce-top-margin {
-    @apply pt-0 -mt-6;
-  }
-  .container-full, .themag-layout--my-default {
-    @apply px-4;
-  }
+
   .section-hero .container-full, 
   .utc-hero-section .container-full {
     @apply p-0;
@@ -518,6 +515,12 @@ ul.pager__items li a:hover {
   .section-hero .container-full .row, 
   .utc-hero-section .container-full .row  {
     @apply mx-0;
+  }
+}
+@media screen and (max-width: 768px) {
+  .section-hero {@apply bg-white shadow-utc}
+  .container-full, .themag-layout--my-default {
+    @apply px-4;
   }
   .container-full .block--region-content-header.block--page-title-block .page-title {
     @apply text-lg;
@@ -550,4 +553,10 @@ ul.pager__items li a:hover {
 foreignObject > div > div {
   display: flex;
   align-items: center;
+}
+
+/****blazy styles***/
+.section-hero .b-bg, .utc-hero-section .b-bg {height:100%!important}
+.is-b-loading:not(.is-b-loaded):not([data-animation])::before {
+  background: #166484!important;
 }

--- a/source/default/tailwind.config.js
+++ b/source/default/tailwind.config.js
@@ -33,6 +33,7 @@
        boxShadow: {
          'utc': '3px 3px 5px 1px rgb(0 0 0 / 15%)',
          'utcdark': 'rgba(0, 0, 0, 0.15) 0px 2px 4px, rgba(0, 0, 0, 0.25) 0px 2px 3px',
+         'utcbottom': 'rgba(0, 0, 0, 0.20) 0px 2px 2px 1px'
        },
        gridTemplateRows: {
          // Adds a custom template for the utc hero block
@@ -71,6 +72,9 @@
          9999: "9999",
          100000: "100000",
        },
+       width: {
+        '95p': '95%',
+       },
        minWidth: {
          '9': '9rem'
        },
@@ -86,12 +90,14 @@
          '90p': '90%',
          '95p': '95%',
          'full': '100%',
-       }
-       ,
+       },
        margin: {
         '20': '5rem',
         '28': '7rem', 
         '36': '9rem',
+       },
+       opacity: {
+        '85': '.85',
        }
      },
      minHeight: {


### PR DESCRIPTION
Reconfigured background images to use existing Blazy component as well as Responsive Background Images. Images now load different sized images based on the device. Is is no longer just resized. Related to Issue #558.