### PR TITLE
Hotfix/utc 2490 minor fix for predeployment 07 2023

### DIFF
--- a/source/default/_patterns/00-protons/legacy/js/back-to-top-button.js
+++ b/source/default/_patterns/00-protons/legacy/js/back-to-top-button.js
@@ -3,33 +3,24 @@
    //Adds slick arrows 
     Drupal.behaviors.backtotopbutton = {
         attach: function(context, settings) {
+            // Get the button:
             let scrollButton = document.getElementById("scroll-to-top-btn");
             scrollButton.style.display = "none";
-            
-            //check to see if the window is tall enough for a back-to-top button
-            function setWindowHeight(){
-              var windowHeight = window.innerHeight;
-                  if (windowHeight > 1500) {
-                    // When the user scrolls down 1500px from the top of the document, show the button
-                    window.onscroll = function() {scrollFunction()};
-                    
-                    window.addEventListener("resize",setWindowHeight,false);
-                      function scrollFunction() {
-                        if (document.body.scrollTop > 1500 || document.documentElement.scrollTop > 1500) {
-                          scrollButton.style.display = "flex";
-                        } else {
-                          scrollButton.style.display = "none";
-                        }
-                      }
-                      // When the user clicks on the button, scroll to the top of the document
-                      function topFunction() {
-                        document.body.scrollTop = 0;
-                        document.documentElement.scrollTop = 0;
-                      }
-                  scrollButton.addEventListener("click", topFunction);
-                }
+            // When the user scrolls down 1500px from the top of the document, show the button
+            window.onscroll = function() {scrollFunction()};
+            function scrollFunction() {
+              if (document.body.scrollTop > 1500 || document.documentElement.scrollTop > 1500) {
+                scrollButton.style.display = "flex";
+              } else {
+                scrollButton.style.display = "none";
+              }
             }
-            setWindowHeight();
+            // When the user clicks on the button, scroll to the top of the document
+            function topFunction() {
+              document.body.scrollTop = 0; // For Safari
+              document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
+            } 
+            scrollButton.addEventListener("click", topFunction);
         }
     };
   }(jQuery, Drupal, drupalSettings));

--- a/source/default/_patterns/00-protons/legacy/js/back-to-top-button.js
+++ b/source/default/_patterns/00-protons/legacy/js/back-to-top-button.js
@@ -1,11 +1,13 @@
-  (function($, Drupal, drupalSettings) {
-    "use strict";
-   //Adds slick arrows 
-    Drupal.behaviors.backtotopbutton = {
-        attach: function(context, settings) {
-            // Get the button:
-            let scrollButton = document.getElementById("scroll-to-top-btn");
+(function($, Drupal, drupalSettings) {
+  "use strict";
+ //Adds slick arrows 
+  Drupal.behaviors.backtotopbutton = {
+      attach: function(context, settings) {
+          // Get the button:
+          let scrollButton = document.getElementById("scroll-to-top-btn");
+          if (scrollButton){
             scrollButton.style.display = "none";
+          
             // When the user scrolls down 1500px from the top of the document, show the button
             window.onscroll = function() {scrollFunction()};
             function scrollFunction() {
@@ -21,7 +23,7 @@
               document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
             } 
             scrollButton.addEventListener("click", topFunction);
-        }
-    };
-  }(jQuery, Drupal, drupalSettings));
-  
+          } 
+      }
+  };
+}(jQuery, Drupal, drupalSettings));


### PR DESCRIPTION
Moving the back-to-top button threw errors in the admin when layout builder was open and edited bc the back to the top button is not present. This simplifies the js and removes those errors.