### PR TITLE
UTC-470: update select form element deprecations.

### DIFF
--- a/source/default/_patterns/01-atoms/form-element/_select.twig
+++ b/source/default/_patterns/01-atoms/form-element/_select.twig
@@ -38,7 +38,6 @@
   <select {{ select_attributes|attributify }}>
     {% block select_content %}
       {% for option in select.options %}
-      {% if key|first != '#' %}
           {% if option.type == 'optgroup' %}
             <optgroup label="{{ option.label }}">
               {% for sub_option in option.options %}
@@ -56,7 +55,6 @@
               {{ option.label }}
             </option>
           {% endif %}
-        {% endif %}
       {% endfor %}
     {% endblock select_content %}
   </select>

--- a/source/default/_patterns/01-atoms/form-element/_select.twig
+++ b/source/default/_patterns/01-atoms/form-element/_select.twig
@@ -34,28 +34,30 @@
     })
 %}
 
-{% spaceless %}
+{% apply spaceless %}
   <select {{ select_attributes|attributify }}>
     {% block select_content %}
       {% for option in select.options %}
-        {% if option.type == 'optgroup' %}
-          <optgroup label="{{ option.label }}">
-            {% for sub_option in option.options %}
-              <option value="{{ sub_option.value }}"
-                {{ sub_option.selected ? ' selected="selected"' }}
-                {{ option.disabled ? ' disabled' }}>
-                {{ sub_option.label }}
-              </option>
-            {% endfor %}
-          </optgroup>
-        {% elseif option.type == 'option' %}
-          <option value="{{ option.value }}"
-            {{ option.selected ? ' selected="selected"' }}
-            {{ option.disabled ? ' disabled' }}>
-            {{ option.label }}
-          </option>
+      {% if key|first != '#' %}
+          {% if option.type == 'optgroup' %}
+            <optgroup label="{{ option.label }}">
+              {% for sub_option in option.options %}
+                <option value="{{ sub_option.value }}"
+                  {{ sub_option.selected ? ' selected="selected"' }}
+                  {{ option.disabled ? ' disabled' }}>
+                  {{ sub_option.label }}
+                </option>
+              {% endfor %}
+            </optgroup>
+          {% elseif option.type == 'option' %}
+            <option value="{{ option.value }}"
+              {{ option.selected ? ' selected="selected"' }}
+              {{ option.disabled ? ' disabled' }}>
+              {{ option.label }}
+            </option>
+          {% endif %}
         {% endif %}
       {% endfor %}
     {% endblock select_content %}
   </select>
-{% endspaceless %}
+{% endapply %}


### PR DESCRIPTION
Related to issue #470: _select.html.twig updates.

Both webform and layout build select options are now updated and functional.

![webform-select](https://github.com/UTCWeb/particle/assets/82905787/a1cbe7c0-1e5e-46dc-a05f-7b2853309745)


![block-select](https://github.com/UTCWeb/particle/assets/82905787/930e7a84-4cd6-4699-9387-30290c557d6f)

