### PR TITLE
UTC-2599: Minor css tweaks for library event calendar.

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/global.css
+++ b/source/default/_patterns/00-protons/legacy/css/global.css
@@ -260,7 +260,7 @@ a {
 }
 a:hover,
 a:focus {
-  @apply text-utc-new-blue-800 font-medium no-underline;
+  @apply text-utc-new-blue-800 no-underline;
 }
 a.focus-visible, a:focus-visible {
   outline: 2px dashed #fdb736;

--- a/source/default/_patterns/00-protons/legacy/css/global.css
+++ b/source/default/_patterns/00-protons/legacy/css/global.css
@@ -599,6 +599,9 @@ foreignObject > div > div {
   display: flex;
   align-items: center;
 }
+.fc-list-item-time, .fc-list-item-title a {
+  font-weight:400;
+}
 
 /****blazy styles***/
 .section-hero .b-bg, .utc-hero-section .b-bg {height:100%!important}


### PR DESCRIPTION
Make all the fonts 400 in the Library Events calendar for uniformity and accessibility.