### PR TITLE
UTC-2606: Fix two row button deprecation for D10.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--block-content--utc-button-group.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--block-content--utc-button-group.html.twig
@@ -29,87 +29,77 @@
 {# removes bottom margin standard with block class #}
 {% set attributes = attributes.removeClass('block') %}
 {% set btn_attribute = create_attribute() %}
-	{% block content %}
-	{% set button_style_select = content["#block_content"].field_button_type.0.target_id %}
-	{% set button_style = drupal_field('field_css_class', 'taxonomy_term', button_style_select)["#object"].field_css_class.value %}
+    {% block content %}
+    {% set button_style_select = content["#block_content"].field_button_type.0.target_id %}
+    {% set button_style = drupal_field('field_css_class', 'taxonomy_term', button_style_select)["#object"].field_css_class.value %}
+    {% set button_group = {
+        title: content.field_button_group_title|field_value,
+        title_align: content["#block_content"].field_button_group_align_title.0.value,
+        title_color: button_style == 'btn btn--white-outline' ? 'btn-group__title--white',
+        top_margin: content["#block_content"].field_button_top_margin.0.value,
+        bottom_margin: content["#block_content"].field_button_bottom_margin.0.value,
+        size:  content.field_button_size|field_value|render,
 
-	{% set button_group = {
-		title: content.field_button_group_title|field_value,
-		title_align: content["#block_content"].field_button_group_align_title.0.value,
-		title_color: button_style == 'btn btn--white-outline' ? 'btn-group__title--white',
-		top_margin: content["#block_content"].field_button_top_margin.0.value,
-		bottom_margin: content["#block_content"].field_button_bottom_margin.0.value,
-		size:  content.field_button_size|field_value|render,
-
-	}
-	%}
-
-	{%
-  set btn_classes = [
-    'btn-block',
-	button_style,
-	'btn--' ~ button_group.size,
-	'btn-group__btn',
-  ]
-%}
-
-		<div{{content_attributes}}>
-			<div class="container {{ button_group.top_margin }} {{ button_group.bottom_margin }}">
-			{% if button_group.title %}
-				<h2 class="btn-group__title {{ button_group.title_color }} {{ button_group.title_align }}">
-					{{ button_group.title }}
-				</h2>
-			{% endif %}
-		{# if two rows is "on", counts number of button fields w/ url content
-		uses number to loop through and separate into rows #}
-			{% if "On" in content.field_two_rows.0 %}
-				{% set btn_count = 0 %}
-          {% for button in content.field_button_link %}
-            {% if button['#url'] is not empty %}
-              {% set btn_count = btn_count + 1 %}
+    }
+    %}
+    {%
+    set btn_classes = [
+        'btn-block',
+        button_style,
+        'btn--' ~ button_group.size,
+        'btn-group__btn',
+    ]
+    %}
+    <div{{content_attributes}}>
+        <div class="container {{ button_group.top_margin }} {{ button_group.bottom_margin }}">
+            {% if button_group.title %}
+                <h2 class="btn-group__title {{ button_group.title_color }} {{ button_group.title_align }}">
+                    {{ button_group.title }}
+                </h2>
             {% endif %}
-          {% endfor %}
+            {# if two rows is "on", counts number of button fields w/ url content uses number to loop through and separate into rows #}
+            {% if "On" in content.field_two_rows.0 %}
 
-				<div class="row two-btn-row btn-row-one">
+                {% set btn_count = 0 %}
+                {% for button in content.field_button_link %}
+                    {% if button['#url'] is not empty %}
+                    	{% set btn_count = btn_count + 1 %}
+                    {% endif %}
+                {% endfor %}
+
+				{% set btn_count_half = btn_count / 2 %}
+				{%
+				set end_count_class = [
+					'mt-4',
+					'half-of-the-btns--' ~ btn_count_half
+				]
+				%}
+
+                <div {{ attributes.addClass(end_count_class) }}>
 					{% for button in content.field_button_link %}
-            {% if button['#url'] is not empty %}
-              {% if loop.index <= (btn_count / 2) %}
-                <div class="col-md mt-4">
-                  <a{{btn_attribute.addClass(btn_classes)}} href="{{ button['#url'] }}">
-                    {{ button['#title']|striptags('<i>')|raw }}
-                  </a>
+						{% if button['#url'] is not empty %}
+							<div class="button-wrapper">
+								<a{{btn_attribute.addClass(btn_classes)}} href="{{ button['#url'] }}">
+									{{ button['#title']|striptags('<i>')|raw }}
+								</a>
+							</div>
+						{% endif %}
+					{% endfor %}
                 </div>
-              {% endif %}
-            {% endif %}
-          {% endfor %}
-				</div>
-				<div class="row two-btn-row btn-row-two">
-					{% for button in content.field_button_link %}
-            {% if button['#url'] is not empty %}
-              {% if loop.index > (btn_count / 2) %}
-                <div class="col-md mt-4">
-                  <a{{btn_attribute.addClass(btn_classes)}} href="{{ button['#url'] }}">
-                    {{ button['#title']|striptags('<i>')|raw }}
-                  </a>
+            {% else %}
+                <div class="row one-row-of-buttons">
+                    {% for button in content.field_button_link %}
+                        {% if button['#url'] is not empty %}
+                        <div class="col-md mt4">
+                            <a{{btn_attribute.addClass(btn_classes)}} href="{{ button['#url'] }}">
+                                {{ button['#title']|striptags('<i>')|raw }}
+                            </a>
+                        </div>
+                        {% endif %}
+                {% endfor %}
                 </div>
-              {% endif %}
             {% endif %}
-          {% endfor %}
-				</div>
-			{% else %}
-				<div class="row one-button-row">
-					{% for button in content.field_button_link %}
-            {% if button['#url'] is not empty %}
-              <div class="col-md mt-4">
-                <a{{btn_attribute.addClass(btn_classes)}} href="{{ button['#url'] }}">
-                  {{ button['#title']|striptags('<i>')|raw }}
-                </a>
-              </div>
-            {% endif %}
-          {% endfor %}
-				</div>
-			{% endif %}
-		</div>
-</div>
-
+        </div>
+    </div>
 {% endblock %}
+

--- a/apps/drupal-default/particle_theme/templates/block/block--block-content--utc-button-group.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--block-content--utc-button-group.html.twig
@@ -87,10 +87,10 @@
 					{% endfor %}
                 </div>
             {% else %}
-                <div class="row one-row-of-buttons">
+                <div class="row one-button-row">
                     {% for button in content.field_button_link %}
                         {% if button['#url'] is not empty %}
-                        <div class="col-md mt4">
+                        <div class="col-md mt-4">
                             <a{{btn_attribute.addClass(btn_classes)}} href="{{ button['#url'] }}">
                                 {{ button['#title']|striptags('<i>')|raw }}
                             </a>

--- a/source/default/_patterns/00-protons/legacy/css/components/buttons/_buttons.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/buttons/_buttons.css
@@ -280,4 +280,36 @@ a.btn--hover-slide:hover::after {
   gap: 1rem;
 }
 
+@media (max-width: 420px) {
+  .half-of-the-btns--1,
+  .half-of-the-btns--1\.5,
+  .half-of-the-btns--2,
+  .half-of-the-btns--2\.5,
+  .half-of-the-btns--3 {
+    display:block!important;
+  } 
+  .button-wrapper{
+    margin-top:1rem;
+  } 
+  .half-of-the-btns--1\.5 .button-wrapper:nth-child(-1n + 3) {
+    grid-column: unset;
+  }
+  .half-of-the-btns--1\.5 .button-wrapper:nth-last-child(1) {
+    grid-row-start: unset;
+    grid-column: unset;
+  }
+  .half-of-the-btns--2\.5 .button-wrapper:nth-child(-1n + 3) {
+    grid-column: unset;
+  }
+  .half-of-the-btns--2\.5 .button-wrapper:nth-last-child(2) {
+    grid-row-start: unset;
+    grid-column: unset;
+  }
+  .half-of-the-btns--2\.5 .button-wrapper:nth-last-child(1) {
+    grid-row-start: unset;
+    grid-column: unset;
+  }
+
+}
+
 

--- a/source/default/_patterns/00-protons/legacy/css/components/buttons/_buttons.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/buttons/_buttons.css
@@ -233,3 +233,51 @@ a.btn--hover-slide::after {
 a.btn--hover-slide:hover::after {
   width: 100%;
 }
+
+/*New button group formats as of Drupal 10 10.31.23. Happy Halloween!*/
+.half-of-the-btns--1 {
+  display: grid!important;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+.half-of-the-btns--1\.5 {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+}
+.half-of-the-btns--1\.5 .button-wrapper:nth-child(-1n + 3) {
+  grid-column: span 1;
+}
+.half-of-the-btns--1\.5 .button-wrapper:nth-last-child(1) {
+  grid-row-start: 2;
+  grid-column: 1 / span 2;
+}
+.half-of-the-btns--2 {
+  display: grid!important;
+  grid-template-rows: auto;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+.half-of-the-btns--2\.5 {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 1rem;
+}
+.half-of-the-btns--2\.5 .button-wrapper:nth-child(-1n + 3) {
+  grid-column: span 2;
+}
+.half-of-the-btns--2\.5 .button-wrapper:nth-last-child(2) {
+  grid-row-start: 2;
+  grid-column: 1 / span 3;
+}
+.half-of-the-btns--2\.5 .button-wrapper:nth-last-child(1) {
+  grid-row-start: 2;
+  grid-column: 4 / span 3;
+}
+.half-of-the-btns--3 {
+  display: grid!important;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 1rem;
+}
+
+


### PR DESCRIPTION
Had to rebuild the twig template and add css to do the work. For some reason, the button group link (block field) counts its indexes past 20, which really makes the `button["url"] is not empty` VERY important. The not empty, of course, only counts the button urls that are "not empty", but the loop.index counts all 20+ of the parent. Soooooo, I removed the loop.index (which makes me sad bc it's a really good way to control arrays) and used css to divide the buttons into two rows. The difficulty was the odd numbered buttons, but that's good now.

**BEFORE:**
![Screenshot 2023-10-31 at 1 33 09 PM](https://github.com/UTCWeb/particle/assets/82905787/64e0fba5-8dfa-467c-9a72-4d8587b584ea)

**AFTER:**
![Screenshot 2023-10-31 at 1 33 02 PM](https://github.com/UTCWeb/particle/assets/82905787/e5d69bb2-b24a-4c21-a57e-b536100dea00)

**Six buttons with long titles, two rows**
![Screenshot 2023-10-31 at 2 36 17 PM](https://github.com/UTCWeb/particle/assets/82905787/d85c92ab-d205-46d8-b808-4df435aa631d)

