### PR TITLE
UTC-2606: Fix vid gallry mb & REALLY improve it.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--utc-video-gallery-block--default.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-video-gallery-block--default.html.twig
@@ -1,0 +1,45 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+{%
+  set classes = [
+	'block--utc-video-gallery-block',
+    'view-mode-default',
+  ]
+%}
+<div {{ attributes.addClass(classes) }}>
+  {{ title_prefix }}
+    {% if label %}
+      <h2{{ title_attributes }}>
+         <span class="title-text">{{ label }}</span>
+      </h2>
+    {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    <div{{ content_attributes }}>{{ content }}</div>
+  {% endblock %}
+</div>

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-video-gallery-block--full.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-video-gallery-block--full.html.twig
@@ -1,0 +1,45 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+{%
+  set classes = [
+	'block--utc-video-gallery-block',
+    'view-mode-full',
+  ]
+%}
+<div {{ attributes.addClass(classes) }}>
+  {{ title_prefix }}
+    {% if label %}
+      <h2{{ title_attributes }}>
+         <span class="title-text">{{ label }}</span>
+      </h2>
+    {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    <div{{ content_attributes }}>{{ content }}</div>
+  {% endblock %}
+</div>

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-video-gallery-block--utc-original-size.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-video-gallery-block--utc-original-size.html.twig
@@ -1,0 +1,45 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+{%
+  set classes = [
+	'block--utc-video-gallery-block',
+    'view-mode-utc-original-size',
+  ]
+%}
+<div {{ attributes.addClass(classes) }}>
+  {{ title_prefix }}
+    {% if label %}
+      <h2{{ title_attributes }}>
+         <span class="title-text">{{ label }}</span>
+      </h2>
+    {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    <div{{ content_attributes }}>{{ content }}</div>
+  {% endblock %}
+</div>

--- a/apps/drupal-default/particle_theme/templates/block/block--utc-video-gallery-block--video-grid.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-video-gallery-block--video-grid.html.twig
@@ -1,0 +1,45 @@
+{#
+/**
+ * @file
+ * Theme override to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ */
+#}
+{%
+  set classes = [
+	'block--utc-video-gallery-block',
+    'view-mode-video-grid',
+  ]
+%}
+<div {{ attributes.addClass(classes) }}>
+  {{ title_prefix }}
+    {% if label %}
+      <h2{{ title_attributes }}>
+         <span class="title-text">{{ label }}</span>
+      </h2>
+    {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    <div{{ content_attributes }}>{{ content }}</div>
+  {% endblock %}
+</div>

--- a/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_video_component.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_video_component.css
@@ -1,13 +1,71 @@
-.video-full-screen .field--name-field-media-video-embed-field {
+.video-full-screen .field--name-field-media-video-embed-field,
+.view-mode-default .field--name-field-media-video-embed-field,
+.view-mode-video-grid .field--name-field-media-video-embed-field,
+.view-mode-full .field--name-field-media-video-embed-field
+ {
     width: 100%!important;
     padding-bottom: 55%;
     position: relative;
 }
 
-.video-full-screen iframe {
+.video-full-screen iframe,
+.view-mode-default iframe,
+.view-mode-video-grid iframe,
+.view-mode-full iframe,
+.view-mode-original iframe {
     width: 100%;
     height: 100%;
     position: absolute;
     top: 0;
     left: 0;
 }
+
+/*Gallery styles*/
+.block--utc-video-gallery-block:not('view-mode-video-grid') .field--name-field-media-video-embed-field {
+    margin-bottom: 2rem!important;
+}
+
+/*video default*/
+.view-mode-default .field__items.video-gallery {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: repeat(4, auto);
+    margin:0 auto;
+  }
+
+/*video grid*/
+.view-mode-video-grid .field__items.video-gallery {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(5, auto);
+    margin:0 auto;
+  }
+
+/*video full*/
+.view-mode-full .field__item, 
+.view-mode-original .field__item {margin-bottom: 2rem!important;}
+
+
+/*video original*/
+.view-mode-utc-original-size .field--name-field-media-video-embed-field {
+    width: 60%!important;
+    padding-bottom: 35%;
+    position: relative;
+    margin: 0 auto
+}
+
+@media (max-width:768px){
+    .view-mode-default .field__items.video-gallery,
+    .view-mode-video-grid .field__items.video-gallery {
+        display:block
+      }
+      .view-mode-default .field__item, 
+      .view-mode-video-grid .field__item {margin-bottom: 2rem!important;}
+      .view-mode-utc-original-size .field--name-field-media-video-embed-field {
+        width: 100%!important;
+        padding-bottom: 55%;
+    }
+}
+


### PR DESCRIPTION
This VASTLY improves the video gallery. Currently, all the video gallery does is stack videos with NO margins top or bottom. This PR improves that and actually makes the view mode choices meaningful. The current view mode choices don't really offer anything different save a size difference and "Full" looks like a thumbnail????

Changes:

- Default: Videos load in a grid of two columns and up to 4 rows on desktop, stacked on mobile with bottom margin.
- Full: Videos are actually full-sized stacked with bottom margin.
- UTC Original Size: These are 60% stacked, centered, with bottom margin.
- Video grid: Videos are loaded in a grid of three columns and up to 5 rows on desktop, stacked on mobile with bottom margin.
