### PR TITLE
UTC-2606: Update video component twig for D10.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--block-content--utc-video-block.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--block-content--utc-video-block.html.twig
@@ -38,15 +38,15 @@
 	{% block content %}
 		<div class="container">
 			{% if video_alignment_val  == 'center' %}
-				<div class="video-center grid justify-center">
+				<div class="video-center block">
 						<div {{content_attributes}}>{{ content.field_utc_video}}</div>
 				</div>
 			{% elseif video_alignment_val == 'left' %}
-				<div class="video-left grid justify-left">
+				<div class="video-left block">
 						<div {{content_attributes}}>{{ content.field_utc_video}}</div>
 				</div>
 			{% elseif video_alignment_val == 'right' %}
-				<div class="video-right grid float-right">
+				<div class="video-right block">
 						<div {{content_attributes}}>{{ content.field_utc_video}}</div>
 				</div>
 			{% elseif video_alignment_val == 'full-screen' %}
@@ -54,7 +54,7 @@
 						<div {{content_attributes}}>{{ content.field_utc_video}}</div>
 				</div>
 			{% else %}
-				<div class="grid justify-center">
+				<div class="video-center block">
 						<div {{content_attributes}}>{{ content.field_utc_video}}</div>
 				</div>
 			{% endif %}

--- a/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_video_component.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_video_component.css
@@ -8,18 +8,39 @@
     position: relative;
 }
 
-.video-full-screen iframe,
 .view-mode-default iframe,
 .view-mode-video-grid iframe,
 .view-mode-full iframe,
 .view-mode-original iframe {
-    width: 100%;
-    height: 100%;
+    width: 80%;
+    height: 80%;
     position: absolute;
     top: 0;
     left: 0;
 }
 
+
+.video-full-screen .view-mode-default iframe {
+    width: 100%;
+    height: 100%;
+}
+
+.video-center .view-mode-default iframe,
+.video-center .view-mode-video-grid iframe,
+.video-center .view-mode-full iframe,
+.video-center .view-mode-original iframe {
+    right: 0;
+    margin: 0 auto;
+}
+.video-right .view-mode-default iframe,
+.video-right .view-mode-video-grid iframe,
+.video-right .view-mode-full iframe,
+.video-right .view-mode-original iframe {
+    right: 0;
+    left: auto;
+}
+
+.view-mode-default iframe,
 /*Gallery styles*/
 .block--utc-video-gallery-block:not('view-mode-video-grid') .field--name-field-media-video-embed-field {
     margin-bottom: 2rem!important;


### PR DESCRIPTION
Fixes "left, right, and center" videos that were not visible with the grid class implemented in the D9 twig file.