### PR TITLE
UTC-569: Apply correct formatting to accrdn link.

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/global.css
+++ b/source/default/_patterns/00-protons/legacy/css/global.css
@@ -289,7 +289,7 @@ ul.link-list li {
 }
 /**end new special lists**/
 /**new special effects links**/
-.UTCtextblock__links a:not(.btn),
+.UTCtextblock__links a:not(.btn):not(.ckeditor-accordion-toggler),
 .utc-card-2__text a:not(.btn):not(.ckeditor-accordion-toggler),
 .utc-sidebar-card a:not(.btn):not(.ckeditor-accordion-toggler),
 .utc-item-card a:not(.btn):not(.ckeditor-accordion-toggler) {
@@ -303,12 +303,16 @@ ul.link-list li {
  background-size: 100% 1px;
  transition: all .3s;
 }
-.UTCtextblock__links a:not(.btn):hover,
+.UTCtextblock__links a:not(.btn):not(.ckeditor-accordion-toggler):hover,
 .utc-card-2__text a:not(.btn):not(.ckeditor-accordion-toggler):hover,
 .utc-sidebar-card a:not(.btn):not(.ckeditor-accordion-toggler):hover,
 .utc-item-card a:not(.btn):not(.ckeditor-accordion-toggler):hover {
   @apply text-utc-new-blue-800;
   background-size: 0% 1px;
+}
+.ckeditor-accordion-container > dl dt > a, .ckeditor-accordion-container > dl dt > a:not(.button) {
+  font-family: "Oswald", sans-serif!important;
+  font-weight: 600!important;
 }
 /**end new special effects links**/
 a:active,


### PR DESCRIPTION
This corrects application of new link formatting to accordion heads:

Bad:
![Screenshot 2024-02-23 at 2 51 17 PM](https://github.com/UTCWeb/particle/assets/82905787/a75a0d8b-c62c-4ed4-b420-1820c4c3ede0)



Good:
![Screenshot 2024-02-23 at 2 51 11 PM](https://github.com/UTCWeb/particle/assets/82905787/89f029a8-5863-401e-bb49-2c143169d5bc)
