### PR TITLE
UTC-626: Rmv link effect on localist widget btns.

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/global.css
+++ b/source/default/_patterns/00-protons/legacy/css/global.css
@@ -310,6 +310,17 @@ ul.link-list li {
   @apply text-utc-new-blue-800;
   background-size: 0% 1px;
 }
+.localist_widget_container .action_button a {
+  text-decoration: none !important;
+  border: 1px solid #112e51 !important;
+  color: #fff !important;
+  background-image: unset !important;
+  background-position: unset !important;
+}
+
+.localist_widget_container .action_button a:hover {
+  color: #112e51 !important;
+}
 .ckeditor-accordion-container > dl dt > a, .ckeditor-accordion-container > dl dt > a:not(.button) {
   font-family: "Oswald", sans-serif!important;
   font-weight: 600!important;


### PR DESCRIPTION
This PR removes link effect on localis widget btns.

Bad:
![localist-link-bad](https://github.com/UTCWeb/particle/assets/82905787/2bbdf5e9-f273-4df5-9242-27596c1e2a02)



Good: 
![localist-link-good](https://github.com/UTCWeb/particle/assets/82905787/2945bdf1-981d-44e0-bdf0-f62358576df8)
