### PR TITLE
UTC-2747: Remove extra scrolling & updt mobile.

### DIFF
--- a/source/default/_patterns/00-protons/legacy/css/pages/utc_academic_programs.css
+++ b/source/default/_patterns/00-protons/legacy/css/pages/utc_academic_programs.css
@@ -1,5 +1,5 @@
 
-.utc-programs-page .layout-container > .container {overflow-x:hidden;}
+/*.utc-programs-page .layout-container > .container {overflow-x:hidden;}*/
 /****View header****/
 
 .utc-programs-page .block--region-content-header.block--page-title-block .page-title, 
@@ -151,8 +151,12 @@ input#edit-field-program-name-value:focus {
   }
   .utc-academic-programs-form .form-checkboxes .form-item label.option {
     font-size: 1.1rem;
-    height: 24px;
     display: inline-block;
+    margin-top: 3px;
+    margin-bottom: 0;
+  }
+  .utc-academic-programs-form .form-type-checkbox {
+    margin-bottom: 9px;
   }
   .utc-academic-programs-form .form-checkboxes input {
     height: 24px;


### PR DESCRIPTION
See [UTCCloud issue #2747](https://github.com/UTCWeb/utccloud/issues/2747) for details.

Note: Ususally `overflow-x: hidden` is implemented when there is a div wider than the viewport on mobile. As I am unable to duplicate any issue relating to that, I'm disabling that property.