### PR TITLE
UTC-2730: Fix highligh 2nd row text-color with full setting.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--utc-highlights-block.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-highlights-block.html.twig
@@ -171,7 +171,7 @@
                 {% if info_2.0['#icons'][loop.index0]['#name'] != 'fa-' %}
                   <div class="mb-4 {{ icon_color }}">
                     <span
-                      class="{{ info_2.0['#icons'][loop.index0]['#style'] }} fad fa-4x {{ info_2.0['#icons'][loop.index0]['#name'] }}" data-fa-mask="" style="--fa-primary-opacity: 1; --fa-secondary-opacity: 1; --fa-primary-color: {{ primary_color_2 }}; --fa-secondary-color: #fdb736;"></span>
+                      class="{{ info_2.0['#icons'][loop.index0]['#style'] }} fad fa-4x {{ info_2.0['#icons'][loop.index0]['#name'] }}" data-fa-mask="" style="--fa-primary-opacity: 1; --fa-secondary-opacity: 1; --fa-primary-color: {{ primary_color_1 }}; --fa-secondary-color: #fdb736;"></span>
                   </div>
                 {% endif %}
                 <span


### PR DESCRIPTION
Before, icon primary color is blue on blue:
![Screenshot 2024-06-05 at 2 33 05 PM](https://github.com/UTCWeb/particle/assets/82905787/f29b81d1-63e1-4a2c-9fbf-4156097cc1c8)




After, icon primary color is white on blue:
![Screenshot 2024-06-05 at 2 53 03 PM](https://github.com/UTCWeb/particle/assets/82905787/2a3c5b48-4d9a-4a87-97f4-c5d1f95d0c08)


Sidebox setting is not affected and is correct:
![Screenshot 2024-06-05 at 2 55 36 PM](https://github.com/UTCWeb/particle/assets/82905787/2ecd31dd-f924-4e4a-a67c-839f15057e5c)

