### PR TITLE
UTC-2796: Bugfix for editable image hero block.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hero--full.html.twig
@@ -6,11 +6,21 @@
 #}
 {%
   set classes = [
+    'block',
+	'block--layout-builder', 
+	'block--inline-block:utc-hero',
 	'block--utc-image-hero',
 	'block--utc-image-hero-full',
   ]
 %}
-{% block content %}
+<div{{ attributes.addClass(classes) }}>
+  {{ title_prefix }}
+    {% if label %}
+      <h2{{ title_attributes }}>
+         <span class="title-text">{{ label }}</span>
+      </h2>
+    {% endif %}
+  {{ title_suffix }}
 	{{ attach_library('utccloud/utc-hero-image') }}
 	{% set rendered_content = content|render %}
 	{# Sets variable to trigger content render array. #}
@@ -55,7 +65,7 @@
 	{% endif %}
 
 	{# image on left #}	 
-	<div {{ attributes.addClass(classes) }}>
+	<div>
 		{% if utc_hero.hero_align == 'Left' %}
 			<div class="utc-hero-block lg:grid lg:grid-rows-utchero lg:grid-cols-utchero lg:gap-y-4 lg:grid-flow-row text-center">
 				{% if utc_hero.hero_image %}
@@ -112,4 +122,4 @@
 					{% endblock herobackground %}
 			</div>
 	</div>
-{% endblock %}
+</div>


### PR DESCRIPTION
This block was missing some critical layout classes which prevented the block from being editable. This error was found at 4p.m. Friday the day before deployment and needed to be fixed.

This issue is reported here: https://github.com/UTCWeb/utccloud/issues/2796
