### PR TITLE
UTC-659: Restore breadcrumbs with correct if statement.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/navigation/breadcrumb.html.twig
+++ b/apps/drupal-default/particle_theme/templates/navigation/breadcrumb.html.twig
@@ -7,7 +7,8 @@
  * - breadcrumb: Breadcrumb trail items.
  */
 #}
-{% if app.request.requestUri == '/degrees-and-programs' %}
+{% set url = url('<current>') %}
+{% if '/enrollment-management-and-student-affairs/advisement/degrees-and-programs' not in url|render|render %}
   {% if breadcrumb %}
     <nav class="simple-breadcrumb utcbreadcrumb" role="navigation" aria-labelledby="system-breadcrumb">
       <h2 id="system-breadcrumb" class="visually-hidden">{{ 'Breadcrumb'|t }}</h2>


### PR DESCRIPTION
Fix for [this issue](https://github.com/UTCWeb/particle/issues/659).

Originally, [this PR](https://github.com/UTCWeb/particle/commit/5ab0b7a752b4541ae987d5fdab09258df1940035) was created to remove duplicate breadcrumbs on the Degrees and Programs page, but it inadvertently removed breadcrumbs on all the pages. This PR corrects the if statement to restore breadcrumbs on all the internal content types while removing the duplicate on the views page... "Degrees and Programs":

**Academic Internal:**

![Screenshot 2024-07-22 at 9 33 22 AM](https://github.com/user-attachments/assets/2dd86f75-d5d7-4712-9f1b-1ce6540345d0)


**Admin Internal:**

![Screenshot 2024-07-22 at 9 33 28 AM](https://github.com/user-attachments/assets/a4a12de7-e50a-427c-b475-4a11b289687f)


**Degrees and programs:**

![Screenshot 2024-07-22 at 9 33 41 AM](https://github.com/user-attachments/assets/69769020-39c3-4927-bfd1-b4a60baca299)

