### PR TITLE
UTC-669: Fix block template suggestions & dist ignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,6 @@ npm-debug.log
 php_errors.log
 
 # Particle
-# dist/
+dist/
 dependencyGraph.json
 patterns.zip

--- a/apps/drupal-default/particle_theme/includes/block.theme.inc
+++ b/apps/drupal-default/particle_theme/includes/block.theme.inc
@@ -33,11 +33,12 @@ function particle_theme_suggestions_block_alter(&$suggestions, $variables)
         }
     } 
     $word= 'node';
+    /*
     if (strpos((string) $node_url_string, $word) !== false) {
         $suggestions[] = ('block__' . "_id_" . $nid . "_label_" . preg_replace('/\s+/', '_', $variables['elements']['#configuration']['label']));
     } else {
         $suggestions[] = ('block__'. str_replace('-', '_', ltrim((string) $node_url_string, '/')) . "_id_" . $nid . "_label_" . preg_replace('/\s+/', '_', $variables['elements']['#configuration']['label']));
-    }
+    }*/
 
     if($variables['elements']['#base_plugin_id'] == 'system_breadcrumb_block'){
         $suggestions[] = 'block__' . $variables['elements']['#base_plugin_id'] . "_" . $node_bundle;


### PR DESCRIPTION
Issue no. #669 
1. Commented out the label and ids of the blocks in template naming conventions as these are unnecessary and throwing invalid errors. See below for images.
2. Uncommented /dist folder in .gitignore so we don't have to manually ignore those.

**BEFORE:**
![Screenshot 2024-08-12 at 5 34 36 PM](https://github.com/user-attachments/assets/bba14df6-7700-425f-a443-f39c1e3943c2)

**AFTER:**
![Screenshot 2024-08-12 at 5 33 54 PM](https://github.com/user-attachments/assets/c1db14d3-0d59-4714-8320-5d6c916a9878)
