### PR TITLE
UTC-2851:   VS-12891: Fixing npm run build:drupal command

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
         "prototyping"
     ],
     "scripts": {
-        "dev:drupal": "cross-env-shell NODE_ENV=development NODE_OPTIONS=--openssl-legacy-provider \"webpack --watch --config ./apps/drupal-default/webpack.config.js\"",
-        "build:drupal": "cross-env-shell NODE_ENV=production NODE_OPTIONS=--openssl-legacy-provider \"webpack --hide-modules --config ./apps/drupal-default/webpack.config.js\"",
+        "dev:drupal": "./node_modules/.bin/cross-env-shell NODE_ENV=development NODE_OPTIONS=--openssl-legacy-provider \"webpack --watch --config ./apps/drupal-default/webpack.config.js\"",
+        "build:drupal": "./node_modules/.bin/cross-env-shell NODE_ENV=production NODE_OPTIONS=--openssl-legacy-provider \"webpack --hide-modules --config ./apps/drupal-default/webpack.config.js\"",
         "lint:js": "eslint --ext .js,.vue ./",
         "lint:css": "stylelint '**/*.css'",
         "lint": "npm run lint:js; npm run lint:css;",


### PR DESCRIPTION
# Pull Request
This PR resolves the failing Travis CI builds in the UTCWeb/utccloud resulting from the inability of travis to resolve the location of the cross-env-shell binary when building the theme.

It is related to https://github.com/UTCWeb/utccloud/pull/2852
