### PR TITLE
UTC-2923: Minor updates to hover cards per MarCom.

### DIFF
--- a/apps/drupal-default/particle_theme/templates/block/block--utc-hover-images.html.twig
+++ b/apps/drupal-default/particle_theme/templates/block/block--utc-hover-images.html.twig
@@ -71,20 +71,35 @@
                 {% if paragraph_url_title %}
                      <figcaption class="absolute block left-0 right-0 w-full cursor-pointer">
                         <div class="utc-border-wrapper">
-                            <div class="hover-inner">
-                                <h2 class="m-0 font-bold capitalize text-utc-new-blue-500 leading-tight">{{ paragraph_title }}</h2>
+                            {% if paragraph_text %}
+                              <div class="hover-inner">
+                                <h2 class="m-0 font-bold text-utc-new-blue-500 leading-tight">{{ paragraph_title }}</h2>
                                 <p class="text-utc-new-blue-500 leading-tight">{{ paragraph_text }}</p>
                                 <a class="hover-button" href="{{ paragraph_url }}" title="{{ paragraph_url_title }}" ><span>{{ paragraph_url_title }}</span></a>
-                            </div>
+                              </div>
+                            {% else %}
+                              <div class="hover-inner no-hover-text">
+                                <h2 class="m-0 font-bold text-utc-new-blue-500 leading-tight">{{ paragraph_title }}</h2>
+                                <a class="hover-button" href="{{ paragraph_url }}" title="{{ paragraph_url_title }}" ><span>{{ paragraph_url_title }}</span></a>
+                              </div>
+                            {% endif %}
                         </div>
                     </figcaption>
                 {% else %}
                     <figcaption class="absolute block left-0 right-0 w-full cursor-default">
                         <div class="utc-border-wrapper">
-                            <div class="hover-inner">
-                                <h2 class="m-0 font-bold capitalize text-utc-new-blue-500 leading-tight">{{ paragraph_title }}</h2>
+                            {% if paragraph_text %}
+                              <div class="hover-inner">
+                                <h2 class="m-0 font-bold text-utc-new-blue-500 leading-tight">{{ paragraph_title }}</h2>
                                 <p class="text-utc-new-blue-500 leading-tight">{{ paragraph_text }}</p>
-                            </div>
+                                <a class="hover-button" href="{{ paragraph_url }}" title="{{ paragraph_url_title }}" ><span>{{ paragraph_url_title }}</span></a>
+                              </div>
+                            {% else %}
+                              <div class="hover-inner no-hover-text">
+                                <h2 class="m-0 font-bold text-utc-new-blue-500 leading-tight">{{ paragraph_title }}</h2>
+                                <a class="hover-button" href="{{ paragraph_url }}" title="{{ paragraph_url_title }}" ><span>{{ paragraph_url_title }}</span></a>
+                              </div>
+                            {% endif %}
                         </div>
                     </figcaption>
                 {% endif %}

--- a/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_hover_images.css
+++ b/source/default/_patterns/00-protons/legacy/css/components/UTC-custom-blocks/_utc_hover_images.css
@@ -36,6 +36,10 @@ figure.utc-hover-image-effect .utc-border-wrapper {
 figure.utc-hover-image-effect .hover-inner {
   @apply border-l-4 border-utc-new-gold-500 pl-4;
 }
+figure.utc-hover-image-effect .hover-inner.no-hover-text {
+  justify-content: center;
+  gap:18px;
+}
 figure.utc-hover-image-effect h2,
 figure.utc-hover-image-effect p {
   @apply opacity-0;


### PR DESCRIPTION
This PR resolutes utccloud issue https://github.com/UTCWeb/utccloud/issues/2923.

- [ ] Make copy block required. (Has to be done in config file in utccloud.)
- [x] Remove extra space when there is no copy for regressive instances.
- [x] Remove "capitalize" class from headline.